### PR TITLE
Centralize orientation handling across UI

### DIFF
--- a/Assets/Scripts/BoostController.cs
+++ b/Assets/Scripts/BoostController.cs
@@ -42,6 +42,12 @@ public class BoostController : MonoBehaviour
         }
 
         UpdateBoostUI();
+
+        if (UIHandler.Instance != null)
+        {
+            UIHandler.Instance.RegisterOrientationObjects(boostBarVertical?.gameObject, boostBarHorizontal?.gameObject);
+            UIHandler.Instance.RegisterOrientationObjects(boostButtonVertical?.gameObject, boostButtonHorizontal?.gameObject);
+        }
     }
 
     void Update()

--- a/Assets/Scripts/ScoreManager.cs
+++ b/Assets/Scripts/ScoreManager.cs
@@ -147,17 +147,8 @@ public class ScoreManager : MonoBehaviour
     }
     public void UpdateGameOverScoreText()
     {
-    if (Screen.orientation == ScreenOrientation.Portrait ||
-        Screen.orientation == ScreenOrientation.PortraitUpsideDown)
-    {
-        scoreResultVertical.text = "Score: " + score;
-        scoreResultHorizontal.text = ""; // 横向きのテキストを空にします。
-    }
-    else if (Screen.orientation == ScreenOrientation.LandscapeLeft || 
-             Screen.orientation == ScreenOrientation.LandscapeRight)
-    {
-        scoreResultHorizontal.text = "Score: " + score;
-        scoreResultVertical.text = ""; // 縦向きのテキストを空にします。
-    }
+        string result = "Score: " + score;
+        scoreResultVertical.text = result;
+        scoreResultHorizontal.text = result;
     }
 }

--- a/Assets/Scripts/TimerController.cs
+++ b/Assets/Scripts/TimerController.cs
@@ -19,6 +19,7 @@ public class TimerController : MonoBehaviour
     void Start()
     {
         currentTime = timeLimit;
+        UIHandler.Instance.RegisterOrientationObjects(timerTextVertical.gameObject, timerTextHorizontal.gameObject);
     }
 
     void Update()
@@ -62,12 +63,6 @@ public class TimerController : MonoBehaviour
         currentTime += amount;
     }
 
-    public void SetTimerVisibility(bool isVerticalVisible, bool isHorizontalVisible)
-    {
-        timerTextVertical.enabled = isVerticalVisible;
-        timerTextHorizontal.enabled = isHorizontalVisible;
-    }
-
     public void GameOver()
     {
         isGameOver = true; // ゲームオーバーフラグを設定
@@ -79,15 +74,7 @@ public class TimerController : MonoBehaviour
             droneController.enabled = false; // DroneController を無効にして動作を停止
         }
 
-        // 画面の向きに応じて適切なゲームオーバー画面を表示
-        if (Screen.orientation == ScreenOrientation.Portrait || Screen.orientation == ScreenOrientation.PortraitUpsideDown)
-        {
-            resultVertical.SetActive(true);
-        }
-        else if (Screen.orientation == ScreenOrientation.LandscapeLeft || Screen.orientation == ScreenOrientation.LandscapeRight)
-        {
-            resultHorizontal.SetActive(true);
-        }
+        UIHandler.Instance.RegisterOrientationObjects(resultVertical, resultHorizontal);
 
         scoreManager.UpdateGameOverScoreText();
         Debug.Log("GameOver method is called");


### PR DESCRIPTION
## Summary
- add UIHandler singleton to manage portrait/landscape elements
- register timer, boost, and result UI pairs with handler
- simplify score update to remove orientation checks

## Testing
- ❌ `dotnet build` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b737454c8321ba91077123966042