### PR TITLE
refactor: use serialized controller references

### DIFF
--- a/Assets/RageRun Games/Easy Flying System/Scripts/CameraController.cs
+++ b/Assets/RageRun Games/Easy Flying System/Scripts/CameraController.cs
@@ -5,7 +5,7 @@ namespace RageRunGames.EasyFlyingSystem
     [DisallowMultipleComponent]
     public class CameraController : MonoBehaviour
     {
-        public Transform target;
+        [SerializeField] private Transform target;
         public float smoothSpeed = 0.125f;
         public Vector3 offset = new Vector3(0f, 2f, -5f);
         private Vector3 currentVel;
@@ -16,13 +16,8 @@ namespace RageRunGames.EasyFlyingSystem
         {
             if (target == null)
             {
-                target = FindObjectOfType<DroneController>().transform;
-
-                if (target == null)
-                {
-                    Debug.LogWarning(
-                        "Fly controller missing in the scene. Please add it in scene and assign target reference on MainCamera");
-                }
+                Debug.LogWarning(
+                    "Fly controller missing in the scene. Please add it in scene and assign target reference on MainCamera");
             }
         }
 

--- a/Assets/Scripts/GameOverController.cs
+++ b/Assets/Scripts/GameOverController.cs
@@ -5,15 +5,12 @@ using RageRunGames.EasyFlyingSystem; // DroneControllerが含まれているname
 public class GameOverController : MonoBehaviour
 {
     public GameObject result; // ゲームオーバー画面のUIパネル
-    public DroneController droneController; // DroneController への参照
+    [SerializeField] private DroneController droneController; // DroneController への参照
 
     void Start()
     {
         // ゲームオーバー画面を非表示にする
         result.SetActive(false);
-
-        // DroneController のインスタンスを取得
-        droneController = FindObjectOfType<DroneController>();
 
         if (droneController == null)
         {

--- a/Assets/Scripts/ItemController.cs
+++ b/Assets/Scripts/ItemController.cs
@@ -11,6 +11,7 @@ public class ItemController : MonoBehaviour
     private Material material;    // オブジェクトのマテリアル
     private Color initialColor;   // 初期カラー
     private bool isShrinking = false;
+    [SerializeField] private ScoreManager scoreManager;
 
     void Start()
     {
@@ -43,7 +44,10 @@ public class ItemController : MonoBehaviour
             }
 
             isShrinking = true;
-            FindObjectOfType<ScoreManager>().AddScore(ringScore);
+            if (scoreManager != null)
+            {
+                scoreManager.AddScore(ringScore);
+            }
 
             BoostController boostController = other.GetComponent<BoostController>();
             if (boostController != null)

--- a/Assets/Scripts/KeyCollector.cs
+++ b/Assets/Scripts/KeyCollector.cs
@@ -2,19 +2,8 @@ using UnityEngine;
 
 public class KeyCollector : MonoBehaviour
 {
-    private TimerController timerController;
-    private ScoreManager scoreManager; 
-
-    private void Start()
-    {
-        // シーン内のUIManagerオブジェクトのUIHandlerスクリプトを探して取得
-        GameObject uiManagerObject = GameObject.Find("UIManager");
-        if (uiManagerObject != null)
-        {
-            timerController = uiManagerObject.GetComponent<TimerController>();
-            scoreManager = FindObjectOfType<ScoreManager>();
-        }
-    }
+    [SerializeField] private TimerController timerController;
+    [SerializeField] private ScoreManager scoreManager;
 
     private void OnTriggerEnter(Collider other)
     {

--- a/Assets/Scripts/StageSelect.cs
+++ b/Assets/Scripts/StageSelect.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 
 public class    StageSelect: MonoBehaviour {
+    [SerializeField] private TimerController timerController;
 
     void OnTriggerEnter (Collider other) {
 
@@ -19,8 +20,14 @@ public class    StageSelect: MonoBehaviour {
             SceneManager.LoadScene("Stage3");
         } else if (this.tag == "Portal" && other.CompareTag("Player"))
         {
-            TimerController timerController = FindObjectOfType<TimerController>();
-            timerController.GameOver();
+            if (timerController != null)
+            {
+                timerController.GameOver();
+            }
+            else
+            {
+                Debug.LogWarning("TimerController reference is not set.");
+            }
         }
     }
 }

--- a/Assets/Scripts/TimerController.cs
+++ b/Assets/Scripts/TimerController.cs
@@ -14,7 +14,8 @@ public class TimerController : MonoBehaviour
     private bool isGameOver = false; // ゲームオーバーフラグ
     public GameObject resultVertical; // 縦向きのときに表示するゲームオーバー画面
     public GameObject resultHorizontal; // 横向きのときに表示するゲームオーバー画面
-    public ScoreManager scoreManager; // ScoreManagerへの参照
+    [SerializeField] private ScoreManager scoreManager; // ScoreManagerへの参照
+    [SerializeField] private DroneController droneController; // DroneControllerへの参照
 
     void Start()
     {
@@ -68,10 +69,13 @@ public class TimerController : MonoBehaviour
         isGameOver = true; // ゲームオーバーフラグを設定
 
         // ゲームオーバー時のプレイヤーの操作を無効にする
-        DroneController droneController = FindObjectOfType<DroneController>();
         if (droneController != null)
         {
             droneController.enabled = false; // DroneController を無効にして動作を停止
+        }
+        else
+        {
+            Debug.LogWarning("DroneController reference is not set.");
         }
 
         UIHandler.Instance.RegisterOrientationObjects(resultVertical, resultHorizontal);


### PR DESCRIPTION
## Summary
- inject TimerController, ScoreManager, and DroneController via serialized fields
- remove FindObjectOfType/GameObject.Find lookups and rely on inspector assignment
- warn when expected references are missing

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2eb4d444483219b846aea5e5d0832