### PR TITLE
Ensure ScoreManager is always referenced

### DIFF
--- a/Assets/Scripts/ItemController.cs
+++ b/Assets/Scripts/ItemController.cs
@@ -23,6 +23,11 @@ public class ItemController : MonoBehaviour
             material = renderer.material;
             initialColor = material.color;
         }
+
+        if (scoreManager == null)
+        {
+            scoreManager = FindObjectOfType<ScoreManager>();
+        }
     }
 
     void Update()

--- a/Assets/Scripts/KeyCollector.cs
+++ b/Assets/Scripts/KeyCollector.cs
@@ -5,6 +5,19 @@ public class KeyCollector : MonoBehaviour
     [SerializeField] private TimerController timerController;
     [SerializeField] private ScoreManager scoreManager;
 
+    private void Awake()
+    {
+        if (timerController == null)
+        {
+            timerController = FindObjectOfType<TimerController>();
+        }
+
+        if (scoreManager == null)
+        {
+            scoreManager = FindObjectOfType<ScoreManager>();
+        }
+    }
+
     private void OnTriggerEnter(Collider other)
     {
         if (other.CompareTag("Player"))

--- a/Assets/Scripts/TimerController.cs
+++ b/Assets/Scripts/TimerController.cs
@@ -21,6 +21,11 @@ public class TimerController : MonoBehaviour
     {
         currentTime = timeLimit;
         UIHandler.Instance.RegisterOrientationObjects(timerTextVertical.gameObject, timerTextHorizontal.gameObject);
+
+        if (scoreManager == null)
+        {
+            scoreManager = FindObjectOfType<ScoreManager>();
+        }
     }
 
     void Update()


### PR DESCRIPTION
## Summary
- Auto-link `ScoreManager` and `TimerController` in `KeyCollector`
- Ensure items and timer locate `ScoreManager` if fields unset
- Allow game over screen to show score even if inspector references are missing

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2fbe09aa483219c05ff2d8f198b8a