### PR TITLE
Allow keyboard debug to blend with mobile pad input

### DIFF
--- a/Assets/RageRun Games/Easy Flying System/Scripts/Inputs/MobileController.cs
+++ b/Assets/RageRun Games/Easy Flying System/Scripts/Inputs/MobileController.cs
@@ -16,6 +16,11 @@ namespace RageRunGames.EasyFlyingSystem
             get { return (snapX) ? SnapInputs(inputVector.x, AxisTypes.Horizontal) : inputVector.x; }
         }
 
+        public Vector2 CurrentInput
+        {
+            get { return inputVector; }
+        }
+
 
         public float RangeValue
         {
@@ -147,14 +152,14 @@ namespace RageRunGames.EasyFlyingSystem
         }
 
     //Keyboard Debug input
-    private void UpdateKnobPosition()
-    {
-    if (knob != null && holder != null)
-    {
-        Vector2 radius = holder.sizeDelta / 2;
-        knob.anchoredPosition = inputVector * radius; // inputVector に基づいてノブの位置を更新
-    }
-    }
+      private void UpdateKnobPosition()
+      {
+      if (knob != null && holder != null)
+      {
+          Vector2 radius = holder.sizeDelta / 2;
+          knob.anchoredPosition = inputVector * radius * rangeValue; // inputVector に基づいてノブの位置を更新
+      }
+      }
 
     public void SetDebugInput(Vector2 debugInput)
     {

--- a/Assets/Scripts/KeyboardToJoystickDebug.cs
+++ b/Assets/Scripts/KeyboardToJoystickDebug.cs
@@ -6,10 +6,11 @@ namespace RageRunGames.EasyFlyingSystem
     public class KeyboardToJoystickDebug : MonoBehaviour
     {
         [SerializeField] private MobileController mobileController; // MobileControllerの参照
-        [SerializeField] private string verticalAxis = "KeyVertical";  // 垂直軸の名前
-        [SerializeField] private string horizontalAxis = "KeyHorizontal"; // 水平軸の名前
         [SerializeField] private bool enableDebugInput = true;      // デバッグ入力を有効化
-        [SerializeField] private bool enableHorizontalInput = false; // 水平軸の入力を有効化
+        [SerializeField] private bool enableHorizontalInput = true; // 水平軸の入力を有効化
+
+        private bool wasKeyboardInput = false; // 前フレームでキーボード入力があったか
+        private Vector2 lastKeyboardVector = Vector2.zero; // 前回適用したキーボード入力
 
         private void Start()
         {
@@ -29,27 +30,52 @@ namespace RageRunGames.EasyFlyingSystem
             if (!enableDebugInput || mobileController == null)
                 return;
 
-            // キーボードの垂直入力を取得
-            float verticalInput = Input.GetAxis(verticalAxis);
+            // キーボード入力を取得
+            float verticalInput = 0f;
+            float horizontalInput = 0f;
+            bool hasInput = false;
 
-            // 水平軸が有効な場合のみキーボードの水平入力を取得
-            float horizontalInput = enableHorizontalInput ? Input.GetAxis(horizontalAxis) : 0f;
+            if (Input.GetKey(KeyCode.W))
+            {
+                verticalInput += 1f;
+                hasInput = true;
+            }
+            if (Input.GetKey(KeyCode.S))
+            {
+                verticalInput -= 1f;
+                hasInput = true;
+            }
 
-            // MobileControllerに入力を適用
-            ApplyKeyboardInputToJoystick(horizontalInput, verticalInput);
-        }
+            if (enableHorizontalInput)
+            {
+                if (Input.GetKey(KeyCode.D))
+                {
+                    horizontalInput += 1f;
+                    hasInput = true;
+                }
+                if (Input.GetKey(KeyCode.A))
+                {
+                    horizontalInput -= 1f;
+                    hasInput = true;
+                }
+            }
 
-        private void ApplyKeyboardInputToJoystick(float horizontal, float vertical)
-        {
-            // 入力ベクトルを作成
-            Vector2 inputVector = new Vector2(horizontal, vertical);
-            inputVector = Vector2.ClampMagnitude(inputVector, 1f); // 入力値を正規化
-
-            // MobileControllerにデバッグ入力を設定
-            mobileController.SetDebugInput(inputVector);
-
-            // デバッグログで確認
-            Debug.Log($"Horizontal Input: {horizontal}, Vertical Input: {vertical}");
+            if (hasInput)
+            {
+                Vector2 mobileInput = mobileController.CurrentInput - lastKeyboardVector;
+                Vector2 keyboardVector = new Vector2(horizontalInput, verticalInput);
+                lastKeyboardVector = keyboardVector;
+                Vector2 combined = Vector2.ClampMagnitude(mobileInput + keyboardVector, 1f);
+                mobileController.SetDebugInput(combined);
+                wasKeyboardInput = true;
+            }
+            else if (wasKeyboardInput)
+            {
+                Vector2 mobileInput = mobileController.CurrentInput - lastKeyboardVector;
+                mobileController.SetDebugInput(mobileInput);
+                lastKeyboardVector = Vector2.zero;
+                wasKeyboardInput = false;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose current joystick input so debug scripts can read swipe state
- blend keyboard WASD debug input with existing mobile pad value and restore swipe control when keys are released

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a32b58fc4c8321a73fc7c548db38b5