### PR TITLE
Constrain Key and Portal spawning to boundary

### DIFF
--- a/Assets/Scripts/ObjectSpawner.cs
+++ b/Assets/Scripts/ObjectSpawner.cs
@@ -44,21 +44,30 @@
                 }
             }
 
-            public Vector3 GetRandomPosition()
-            {
+        public Vector3 GetRandomPosition()
+        {
+                if (boundary == null)
+                {
+                    Debug.LogError("Boundary not set for ObjectSpawner.");
+                    return Vector3.zero;
+                }
+
                 float randomX = Random.Range(minX, maxX);
                 float randomZ = Random.Range(minZ, maxZ);
 
-                // 地形の高さをXとZの位置でサンプリング
+                // 地形の高さをXとZの位置でサンプリング（Terrain が存在する場合のみ）
                 Terrain terrain = Terrain.activeTerrain;
-                float terrainHeight = terrain.SampleHeight(new Vector3(randomX, 0, randomZ));
+                float minYAdjusted = minY;
+                if (terrain != null)
+                {
+                    float terrainHeight = terrain.SampleHeight(new Vector3(randomX, 0, randomZ));
+                    minYAdjusted = Mathf.Max(minY, terrainHeight);
+                }
 
-                // Y座標の最小値として地形の高さと境界の最小値の高い方を使用
-                float minYAdjusted = Mathf.Max(minY, terrainHeight);
                 float randomY = Random.Range(minYAdjusted, maxY);
 
                 return new Vector3(randomX, randomY, randomZ);
-            }
+        }
 
             public void SpawnObject()
             {

--- a/Assets/Scripts/ObjectSpawner.cs
+++ b/Assets/Scripts/ObjectSpawner.cs
@@ -5,22 +5,47 @@
         public class ObjectSpawner : MonoBehaviour
         {
             public GameObject[] keyPrefabs; // 4つのKeyのプレハブを格納する配列
-            public float minX;
-            public float maxX;
-            public float minY;
-            public float maxY;
-            public float minZ; // 最小Z座標
-            public float maxZ; // 最大Z座標
+            public BoxCollider boundary; // スポーン範囲を定義するBoundary
+
+            private float minX;
+            private float maxX;
+            private float minY;
+            private float maxY;
+            private float minZ; // 最小Z座標
+            private float maxZ; // 最大Z座標
 
             private int objectsCollected = 0;
             private int currentKeyIndex = 0; // 現在のKeyのインデックス
 
-            public void SpawnObject()
+            private void Awake()
             {
-                if(objectsCollected >= 4){
-                    return;
+                if (boundary == null)
+                {
+                    GameObject boundaryObject = GameObject.FindWithTag("boundary");
+                    if (boundaryObject != null)
+                    {
+                        boundary = boundaryObject.GetComponent<BoxCollider>();
+                    }
                 }
-                // ランダムなXとZ座標を計算
+
+                if (boundary != null)
+                {
+                    Bounds bounds = boundary.bounds;
+                    minX = bounds.min.x;
+                    maxX = bounds.max.x;
+                    minY = bounds.min.y;
+                    maxY = bounds.max.y;
+                    minZ = bounds.min.z;
+                    maxZ = bounds.max.z;
+                }
+                else
+                {
+                    Debug.LogError("Boundary not set for ObjectSpawner.");
+                }
+            }
+
+            public Vector3 GetRandomPosition()
+            {
                 float randomX = Random.Range(minX, maxX);
                 float randomZ = Random.Range(minZ, maxZ);
 
@@ -28,10 +53,20 @@
                 Terrain terrain = Terrain.activeTerrain;
                 float terrainHeight = terrain.SampleHeight(new Vector3(randomX, 0, randomZ));
 
-                // Y座標の最小値として地形の高さを使用し、最大値としてmaxYを使用してランダムな値を取得
-                float randomY = Random.Range(terrainHeight, maxY);
+                // Y座標の最小値として地形の高さと境界の最小値の高い方を使用
+                float minYAdjusted = Mathf.Max(minY, terrainHeight);
+                float randomY = Random.Range(minYAdjusted, maxY);
 
-                Vector3 randomPosition = new Vector3(randomX, randomY, randomZ);
+                return new Vector3(randomX, randomY, randomZ);
+            }
+
+            public void SpawnObject()
+            {
+                if(objectsCollected >= 4){
+                    return;
+                }
+
+                Vector3 randomPosition = GetRandomPosition();
 
                 GameObject prefabToSpawn = keyPrefabs[currentKeyIndex];
                 GameObject spawnedObject = Instantiate(prefabToSpawn, randomPosition, Quaternion.identity);

--- a/Assets/Scripts/ScoreManager.cs
+++ b/Assets/Scripts/ScoreManager.cs
@@ -121,18 +121,7 @@ public class ScoreManager : MonoBehaviour
 
     private void SpawnNewObject()
     {
-        // ランダムなXとZ座標を計算
-        float randomX = Random.Range(objectSpawner.minX, objectSpawner.maxX);
-        float randomZ = Random.Range(objectSpawner.minZ, objectSpawner.maxZ);
-
-        // 地形の高さをXとZの位置でサンプリング
-        Terrain terrain = Terrain.activeTerrain;
-        float terrainHeight = terrain.SampleHeight(new Vector3(randomX, 0, randomZ));
-
-        // Y座標の最小値として地形の高さを使用し、最大値としてobjectSpawner.maxYを使用してランダムな値を取得
-        float randomY = Random.Range(terrainHeight, objectSpawner.maxY);
-
-        Vector3 randomPosition = new Vector3(randomX, randomY, randomZ);
+        Vector3 randomPosition = objectSpawner.GetRandomPosition();
 
         GameObject spawnedPortal = Instantiate(Portal, randomPosition, Quaternion.identity);
         spawnedPortal.SetActive(false);


### PR DESCRIPTION
## Summary
- Derive spawn bounds from a `Boundary` BoxCollider and expose `GetRandomPosition` in `ObjectSpawner`
- Use the shared `GetRandomPosition` to spawn portals within the same bounds

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be2f4db7248321933b16f602690591