### PR TITLE
Enable boost with space key for debugging

### DIFF
--- a/Assets/Scripts/BoostController.cs
+++ b/Assets/Scripts/BoostController.cs
@@ -52,6 +52,19 @@ public class BoostController : MonoBehaviour
 
     void Update()
     {
+        // For debugging: allow boosting with the space key
+        if (Input.GetKey(KeyCode.Space))
+        {
+            if (!isBoosting && currentBoost > 0)
+            {
+                EnableBoost();
+            }
+        }
+        else if (isBoosting)
+        {
+            DisableBoost();
+        }
+
         if (isBoosting && currentBoost > 0)
         {
             // ブースト中にゲージを消費


### PR DESCRIPTION
## Summary
- Allow boosting using the space key for easier debugging

## Testing
- ⚠️ `dotnet test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be376f8c708321bad5d6d95c3c6f9c