### PR TITLE
Respawn boost particles with updated color

### DIFF
--- a/Assets/Scripts/BoostController.cs
+++ b/Assets/Scripts/BoostController.cs
@@ -161,12 +161,16 @@ public class BoostController : MonoBehaviour
         if (leftHandParticle != null)
         {
             var main = leftHandParticle.main;
-            main.startColor = leftColor;
+            main.startColor = new ParticleSystem.MinMaxGradient(leftColor);
+            leftHandParticle.Clear();
+            leftHandParticle.Play();
         }
         if (rightHandParticle != null)
         {
             var main = rightHandParticle.main;
-            main.startColor = rightColor;
+            main.startColor = new ParticleSystem.MinMaxGradient(rightColor);
+            rightHandParticle.Clear();
+            rightHandParticle.Play();
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure boost particle systems use MinMaxGradient and respawn after color changes
- allow EnableBoost/DisableBoost to visibly change particle colors

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be44aea81483218fe25ceb3bc37c0a