### PR TITLE
Change trail color on boost

### DIFF
--- a/Assets/Scenes/Stage1.unity
+++ b/Assets/Scenes/Stage1.unity
@@ -56229,6 +56229,10 @@ MonoBehaviour:
   boostSpeedMultiplier: 2
   boostButtonVertical: {fileID: 1952864368}
   boostButtonHorizontal: {fileID: 1429971185}
+  leftHandParticle: {fileID: 971091789}
+  rightHandParticle: {fileID: 645646772}
+  leftTrail: {fileID: 0}
+  rightTrail: {fileID: 0}
 --- !u!1 &2104318828
 GameObject:
   m_ObjectHideFlags: 0
@@ -56278,12 +56282,7 @@ MonoBehaviour:
   - {fileID: 195601528}
   - {fileID: 1763385226}
   - {fileID: 615268679}
-  minX: -320
-  maxX: -440
-  minY: 20
-  maxY: 50
-  minZ: 0
-  maxZ: 150
+  boundary: {fileID: 0}
 --- !u!1001 &2104912304
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/BoostController.cs
+++ b/Assets/Scripts/BoostController.cs
@@ -15,6 +15,8 @@ public class BoostController : MonoBehaviour
 
     public ParticleSystem leftHandParticle;  // 左手のパーティクル
     public ParticleSystem rightHandParticle; // 右手のパーティクル
+    public TrailRenderer leftTrail;          // 左手のトレイル
+    public TrailRenderer rightTrail;         // 右手のトレイル
 
     private bool isBoosting = false;  // ブーストが有効かどうか
     private float currentBoost;       // 現在のブースト量
@@ -62,6 +64,9 @@ public class BoostController : MonoBehaviour
         {
             rightOriginalColor = rightHandParticle.main.startColor.color;
         }
+
+        // トレイルの初期色を白に設定
+        SetTrailColor(Color.white, Color.white);
     }
 
     void Update()
@@ -120,6 +125,7 @@ public class BoostController : MonoBehaviour
         isBoosting = true;
         UpdateButtonColor();
         SetParticleColor(Color.yellow, Color.yellow);
+        SetTrailColor(Color.yellow, Color.yellow);
     }
 
     private void DisableBoost()
@@ -127,6 +133,7 @@ public class BoostController : MonoBehaviour
         isBoosting = false;
         UpdateButtonColor();
         SetParticleColor(leftOriginalColor, rightOriginalColor);
+        SetTrailColor(Color.white, Color.white);
     }
 
     private void UpdateBoostUI()
@@ -167,6 +174,18 @@ public class BoostController : MonoBehaviour
         {
             var main = rightHandParticle.main;
             main.startColor = rightColor;
+        }
+    }
+
+    private void SetTrailColor(Color leftColor, Color rightColor)
+    {
+        if (leftTrail != null)
+        {
+            leftTrail.startColor = leftColor;
+        }
+        if (rightTrail != null)
+        {
+            rightTrail.startColor = rightColor;
         }
     }
 


### PR DESCRIPTION
## Summary
- Set Trail-L and Trail-R start colors to yellow during boost
- Restore trail start colors to white when boost ends

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be46fc91a0832185210dbe840d0f1a