### PR TITLE
Add collision-aware object spawn positions

### DIFF
--- a/Assets/Scenes/Stage1.unity
+++ b/Assets/Scenes/Stage1.unity
@@ -5290,7 +5290,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ab74a9961d3c01c48ad6c05a22f2afb0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  timerController: {fileID: 0}
+  timerController: {fileID: 1984864535}
 --- !u!65 &308398863
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -56282,7 +56282,11 @@ MonoBehaviour:
   - {fileID: 195601528}
   - {fileID: 1763385226}
   - {fileID: 615268679}
-  boundary: {fileID: 0}
+  boundary: {fileID: 666989922}
+  spawnRadius: 0.5
+  blockingLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
 --- !u!1001 &2104912304
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ObjectSpawner.cs
+++ b/Assets/Scripts/ObjectSpawner.cs
@@ -6,6 +6,8 @@
         {
             public GameObject[] keyPrefabs; // 4つのKeyのプレハブを格納する配列
             public BoxCollider boundary; // スポーン範囲を定義するBoundary
+            public float spawnRadius = 0.5f; // 半径のコリジョンチェック
+            public LayerMask blockingLayers = ~0; // スポーンをブロックするレイヤーマスク
 
             private float minX;
             private float maxX;
@@ -52,21 +54,23 @@
                     return Vector3.zero;
                 }
 
-                float randomX = Random.Range(minX, maxX);
-                float randomZ = Random.Range(minZ, maxZ);
-
-                // 地形の高さをXとZの位置でサンプリング（Terrain が存在する場合のみ）
-                Terrain terrain = Terrain.activeTerrain;
-                float minYAdjusted = minY;
-                if (terrain != null)
+                const int maxAttempts = 20;
+                Vector3 candidate = Vector3.zero;
+                for (int i = 0; i < maxAttempts; i++)
                 {
-                    float terrainHeight = terrain.SampleHeight(new Vector3(randomX, 0, randomZ));
-                    minYAdjusted = Mathf.Max(minY, terrainHeight);
+                    float randomX = Random.Range(minX, maxX);
+                    float randomY = Random.Range(minY, maxY);
+                    float randomZ = Random.Range(minZ, maxZ);
+                    candidate = new Vector3(randomX, randomY, randomZ);
+
+                    if (!Physics.CheckSphere(candidate, spawnRadius, blockingLayers))
+                    {
+                        return candidate;
+                    }
                 }
 
-                float randomY = Random.Range(minYAdjusted, maxY);
-
-                return new Vector3(randomX, randomY, randomZ);
+                Debug.LogWarning($"No valid spawn position found after {maxAttempts} attempts. Returning last candidate: {candidate}");
+                return candidate;
         }
 
             public void SpawnObject()

--- a/Assets/Scripts/ObjectSpawner.cs
+++ b/Assets/Scripts/ObjectSpawner.cs
@@ -9,13 +9,6 @@
             public float spawnRadius = 0.5f; // 半径のコリジョンチェック
             public LayerMask blockingLayers = ~0; // スポーンをブロックするレイヤーマスク
 
-            private float minX;
-            private float maxX;
-            private float minY;
-            private float maxY;
-            private float minZ; // 最小Z座標
-            private float maxZ; // 最大Z座標
-
             private int objectsCollected = 0;
             private int currentKeyIndex = 0; // 現在のKeyのインデックス
 
@@ -30,17 +23,7 @@
                     }
                 }
 
-                if (boundary != null)
-                {
-                    Bounds bounds = boundary.bounds;
-                    minX = bounds.min.x;
-                    maxX = bounds.max.x;
-                    minY = bounds.min.y;
-                    maxY = bounds.max.y;
-                    minZ = bounds.min.z;
-                    maxZ = bounds.max.z;
-                }
-                else
+                if (boundary == null)
                 {
                     Debug.LogError("Boundary not set for ObjectSpawner.");
                 }
@@ -56,12 +39,16 @@
 
                 const int maxAttempts = 20;
                 Vector3 candidate = Vector3.zero;
+                Vector3 center = boundary.center;
+                Vector3 size = boundary.size;
                 for (int i = 0; i < maxAttempts; i++)
                 {
-                    float randomX = Random.Range(minX, maxX);
-                    float randomY = Random.Range(minY, maxY);
-                    float randomZ = Random.Range(minZ, maxZ);
-                    candidate = new Vector3(randomX, randomY, randomZ);
+                    Vector3 localOffset = new Vector3(
+                        Random.Range(-size.x * 0.5f, size.x * 0.5f),
+                        Random.Range(-size.y * 0.5f, size.y * 0.5f),
+                        Random.Range(-size.z * 0.5f, size.z * 0.5f)
+                    );
+                    candidate = boundary.transform.TransformPoint(center + localOffset);
 
                     if (!Physics.CheckSphere(candidate, spawnRadius, blockingLayers))
                     {


### PR DESCRIPTION
## Summary
- sample spawn positions uniformly within bounds
- avoid collisions by checking with Physics.CheckSphere and retrying up to 20 times
- expose spawn radius and blocking layer mask to control spawn blocking

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be5b214a6c8321ab41a84b8ab51e88