### PR TITLE
Extend timer with chain bonuses and show UI in game view

### DIFF
--- a/Assets/Scripts/ScoreManager.cs
+++ b/Assets/Scripts/ScoreManager.cs
@@ -17,6 +17,7 @@ public class ScoreManager : MonoBehaviour
     public GameObject Portal;
     public GameObject ItemSet;
     public ObjectSpawner objectSpawner;
+    [SerializeField] private TimerController timerController; // タイマー制御
 
     private int keyCount = 0;
     private int score = 0;
@@ -35,6 +36,11 @@ public class ScoreManager : MonoBehaviour
         chainTextHorizontal.gameObject.SetActive(false);
         chainTextVertical.gameObject.SetActive(false);
         UpdateKeyCountText();
+
+        if (timerController == null)
+        {
+            timerController = FindObjectOfType<TimerController>();
+        }
     }
 
     private void Update()
@@ -99,6 +105,11 @@ public class ScoreManager : MonoBehaviour
         else
         {
             chainCount = 1;
+        }
+
+        if (timerController != null)
+        {
+            timerController.AddTime(chainCount * 0.5f);
         }
 
         score += amount;

--- a/Assets/Scripts/UIHandler.cs
+++ b/Assets/Scripts/UIHandler.cs
@@ -47,7 +47,8 @@ public class UIHandler : MonoBehaviour
     public bool IsPortrait()
     {
         return Screen.orientation == ScreenOrientation.Portrait ||
-               Screen.orientation == ScreenOrientation.PortraitUpsideDown;
+               Screen.orientation == ScreenOrientation.PortraitUpsideDown ||
+               Screen.height > Screen.width;
     }
 
     private struct OrientationPair


### PR DESCRIPTION
## Summary
- Add TimerController reference to ScoreManager and extend time limit by chain count x0.5s
- Determine portrait mode via screen size so UI displays when Simulator is off

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be65aa84388321bb2c47764702a428