### PR TITLE
Expose chain and key time bonuses

### DIFF
--- a/Assets/Scripts/KeyCollector.cs
+++ b/Assets/Scripts/KeyCollector.cs
@@ -4,6 +4,7 @@ public class KeyCollector : MonoBehaviour
 {
     [SerializeField] private TimerController timerController;
     [SerializeField] private ScoreManager scoreManager;
+    [SerializeField] private float keyTimeBonus = 60f; // Time added when a key is collected
 
     private void Awake()
     {
@@ -24,7 +25,7 @@ public class KeyCollector : MonoBehaviour
         {
             if (timerController != null)
             {
-                timerController.AddTime(60f);  // タイマーにx秒を追加
+                timerController.AddTime(keyTimeBonus);  // タイマーにx秒を追加
             }
 
             if (scoreManager != null)

--- a/Assets/Scripts/ScoreManager.cs
+++ b/Assets/Scripts/ScoreManager.cs
@@ -26,6 +26,7 @@ public class ScoreManager : MonoBehaviour
     private float lastItemTime;
     public float chainTime = 0.5f;
     public float chainMultiplier = 1.25f;
+    public float chainTimeIncrease = 0.5f; // Time added per chain count
 
     private int[] scoreThresholds = { 1000, 2000, 3000, 4000 };
     private bool[] hasSpawned = { false, false, false, false };
@@ -109,7 +110,7 @@ public class ScoreManager : MonoBehaviour
 
         if (timerController != null)
         {
-            timerController.AddTime(chainCount * 0.5f);
+            timerController.AddTime(chainCount * chainTimeIncrease);
         }
 
         score += amount;


### PR DESCRIPTION
## Summary
- allow chain combo time bonus to be configured in ScoreManager
- expose key collection time bonus for KeyCollector

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68be682569308321997abd19df1c98f5