### PR TITLE
Use chain count to extend timer

### DIFF
--- a/Assets/Scripts/ScoreManager.cs
+++ b/Assets/Scripts/ScoreManager.cs
@@ -26,7 +26,6 @@ public class ScoreManager : MonoBehaviour
     private float lastItemTime;
     public float chainTime = 0.5f;
     public float chainMultiplier = 1.25f;
-    public float chainTimeIncrease = 0.5f; // Time added per chain count
 
     private int[] scoreThresholds = { 1000, 2000, 3000, 4000 };
     private bool[] hasSpawned = { false, false, false, false };
@@ -110,7 +109,8 @@ public class ScoreManager : MonoBehaviour
 
         if (timerController != null)
         {
-            timerController.AddTime(chainCount * chainTimeIncrease);
+            int chainSeconds = chainCount >= 2 ? chainCount - 1 : 0; // 3 chain -> +3 seconds
+            timerController.AddTime(chainSeconds);
         }
 
         score += amount;


### PR DESCRIPTION
## Summary
- add time bonus based on chain count so 3 chain adds 3 seconds

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be6a3fad708321af3138a962df2e4c