### PR TITLE
Randomize item pickup sound

### DIFF
--- a/Assets/Scripts/ScoreManager.cs
+++ b/Assets/Scripts/ScoreManager.cs
@@ -34,6 +34,7 @@ public class ScoreManager : MonoBehaviour
     private AudioSource bgmSource;
     private AudioSource sfxSource;
     private AudioClip[] chainClips;
+    private AudioClip currentChainClip;
 
     [SerializeField, Range(0f, 1f)] private float bgmVolume = 1f;
     [SerializeField] private float bgmStartTime = 0f;
@@ -67,6 +68,7 @@ public class ScoreManager : MonoBehaviour
             chainCount = 0;
             chainTextHorizontal.gameObject.SetActive(false);
             chainTextVertical.gameObject.SetActive(false);
+            currentChainClip = null;
         }
 
         // スコアが閾値を超える場合にオブジェクトをスポーン
@@ -205,11 +207,15 @@ public class ScoreManager : MonoBehaviour
             return;
         }
 
-        int index = Random.Range(0, chainClips.Length);
-        AudioClip clip = chainClips[index];
-        if (clip != null)
+        if (chainCount <= 1 || currentChainClip == null)
         {
-            sfxSource.PlayOneShot(clip, sfxVolume);
+            int index = Random.Range(0, chainClips.Length);
+            currentChainClip = chainClips[index];
+        }
+
+        if (currentChainClip != null)
+        {
+            sfxSource.PlayOneShot(currentChainClip, sfxVolume);
         }
     }
 }

--- a/Assets/Scripts/ScoreManager.cs
+++ b/Assets/Scripts/ScoreManager.cs
@@ -205,7 +205,7 @@ public class ScoreManager : MonoBehaviour
             return;
         }
 
-        int index = Mathf.Clamp(chainCount - 1, 0, chainClips.Length - 1);
+        int index = Random.Range(0, chainClips.Length);
         AudioClip clip = chainClips[index];
         if (clip != null)
         {

--- a/Assets/Scripts/ScoreManager.cs
+++ b/Assets/Scripts/ScoreManager.cs
@@ -34,7 +34,7 @@ public class ScoreManager : MonoBehaviour
     private AudioSource bgmSource;
     private AudioSource sfxSource;
     private AudioClip[] chainClips;
-    private AudioClip currentChainClip;
+    private AudioClip lastPickupClip;
 
     [SerializeField, Range(0f, 1f)] private float bgmVolume = 1f;
     [SerializeField] private float bgmStartTime = 0f;
@@ -68,7 +68,6 @@ public class ScoreManager : MonoBehaviour
             chainCount = 0;
             chainTextHorizontal.gameObject.SetActive(false);
             chainTextVertical.gameObject.SetActive(false);
-            currentChainClip = null;
         }
 
         // スコアが閾値を超える場合にオブジェクトをスポーン
@@ -207,15 +206,20 @@ public class ScoreManager : MonoBehaviour
             return;
         }
 
-        if (chainCount <= 1 || currentChainClip == null)
+        if (chainCount > 1)
         {
             int index = Random.Range(0, chainClips.Length);
-            currentChainClip = chainClips[index];
+            lastPickupClip = chainClips[index];
+        }
+        else if (lastPickupClip == null)
+        {
+            int index = Random.Range(0, chainClips.Length);
+            lastPickupClip = chainClips[index];
         }
 
-        if (currentChainClip != null)
+        if (lastPickupClip != null)
         {
-            sfxSource.PlayOneShot(currentChainClip, sfxVolume);
+            sfxSource.PlayOneShot(lastPickupClip, sfxVolume);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Randomize item pickup sounds by selecting a random clip from the available six options instead of relying on chain count

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ce139ee883218c85ceeedec43b3a