### PR TITLE
Make boost trails turn yellow during boost

### DIFF
--- a/Assets/Scripts/BoostController.cs
+++ b/Assets/Scripts/BoostController.cs
@@ -25,10 +25,8 @@ public class BoostController : MonoBehaviour
     private float originalMaxSpeed;   // 初期の最大速度を保存
     private Color leftOriginalColor;   // 左手パーティクルの元の色
     private Color rightOriginalColor;  // 右手パーティクルの元の色
-    private Color leftTrailOriginalStartColor;  // 左手トレイルの元の開始色
-    private Color leftTrailOriginalEndColor;    // 左手トレイルの元の終了色
-    private Color rightTrailOriginalStartColor; // 右手トレイルの元の開始色
-    private Color rightTrailOriginalEndColor;   // 右手トレイルの元の終了色
+    private Gradient leftTrailOriginalGradient;  // 左手トレイルの元のグラデーション
+    private Gradient rightTrailOriginalGradient; // 右手トレイルの元のグラデーション
 
     void Awake()
     {
@@ -71,13 +69,11 @@ public class BoostController : MonoBehaviour
 
         if (leftTrail != null)
         {
-            leftTrailOriginalStartColor = leftTrail.startColor;
-            leftTrailOriginalEndColor = leftTrail.endColor;
+            leftTrailOriginalGradient = CloneGradient(leftTrail.colorGradient);
         }
         if (rightTrail != null)
         {
-            rightTrailOriginalStartColor = rightTrail.startColor;
-            rightTrailOriginalEndColor = rightTrail.endColor;
+            rightTrailOriginalGradient = CloneGradient(rightTrail.colorGradient);
         }
     }
 
@@ -191,30 +187,56 @@ public class BoostController : MonoBehaviour
 
     private void SetTrailColor(Color leftColor, Color rightColor)
     {
-        if (leftTrail != null)
-        {
-            leftTrail.startColor = leftColor;
-            leftTrail.endColor = leftColor;
-        }
-        if (rightTrail != null)
-        {
-            rightTrail.startColor = rightColor;
-            rightTrail.endColor = rightColor;
-        }
+        ApplySolidColorToTrail(leftTrail, leftColor);
+        ApplySolidColorToTrail(rightTrail, rightColor);
     }
 
     private void RestoreTrailColor()
     {
-        if (leftTrail != null)
+        if (leftTrail != null && leftTrailOriginalGradient != null)
         {
-            leftTrail.startColor = leftTrailOriginalStartColor;
-            leftTrail.endColor = leftTrailOriginalEndColor;
+            leftTrail.colorGradient = CloneGradient(leftTrailOriginalGradient);
         }
-        if (rightTrail != null)
+        if (rightTrail != null && rightTrailOriginalGradient != null)
         {
-            rightTrail.startColor = rightTrailOriginalStartColor;
-            rightTrail.endColor = rightTrailOriginalEndColor;
+            rightTrail.colorGradient = CloneGradient(rightTrailOriginalGradient);
         }
+    }
+
+    private void ApplySolidColorToTrail(TrailRenderer trail, Color color)
+    {
+        if (trail == null)
+        {
+            return;
+        }
+
+        var gradient = new Gradient();
+        gradient.SetKeys(
+            new[]
+            {
+                new GradientColorKey(color, 0f),
+                new GradientColorKey(color, 1f)
+            },
+            new[]
+            {
+                new GradientAlphaKey(color.a, 0f),
+                new GradientAlphaKey(color.a, 1f)
+            }
+        );
+
+        trail.colorGradient = gradient;
+    }
+
+    private Gradient CloneGradient(Gradient gradient)
+    {
+        if (gradient == null)
+        {
+            return null;
+        }
+
+        var clone = new Gradient();
+        clone.SetKeys(gradient.colorKeys, gradient.alphaKeys);
+        return clone;
     }
 
     public void RecoverBoost(float amount)

--- a/Assets/Scripts/BoostController.cs
+++ b/Assets/Scripts/BoostController.cs
@@ -193,14 +193,8 @@ public class BoostController : MonoBehaviour
 
     private void RestoreTrailColor()
     {
-        if (leftTrail != null && leftTrailOriginalGradient != null)
-        {
-            leftTrail.colorGradient = CloneGradient(leftTrailOriginalGradient);
-        }
-        if (rightTrail != null && rightTrailOriginalGradient != null)
-        {
-            rightTrail.colorGradient = CloneGradient(rightTrailOriginalGradient);
-        }
+        RestoreTrailGradient(leftTrail, leftTrailOriginalGradient);
+        RestoreTrailGradient(rightTrail, rightTrailOriginalGradient);
     }
 
     private void ApplySolidColorToTrail(TrailRenderer trail, Color color)
@@ -225,6 +219,18 @@ public class BoostController : MonoBehaviour
         );
 
         trail.colorGradient = gradient;
+        trail.Clear();
+    }
+
+    private void RestoreTrailGradient(TrailRenderer trail, Gradient originalGradient)
+    {
+        if (trail == null || originalGradient == null)
+        {
+            return;
+        }
+
+        trail.colorGradient = CloneGradient(originalGradient);
+        trail.Clear();
     }
 
     private Gradient CloneGradient(Gradient gradient)

--- a/Assets/Scripts/BoostController.cs
+++ b/Assets/Scripts/BoostController.cs
@@ -25,6 +25,10 @@ public class BoostController : MonoBehaviour
     private float originalMaxSpeed;   // 初期の最大速度を保存
     private Color leftOriginalColor;   // 左手パーティクルの元の色
     private Color rightOriginalColor;  // 右手パーティクルの元の色
+    private Color leftTrailOriginalStartColor;  // 左手トレイルの元の開始色
+    private Color leftTrailOriginalEndColor;    // 左手トレイルの元の終了色
+    private Color rightTrailOriginalStartColor; // 右手トレイルの元の開始色
+    private Color rightTrailOriginalEndColor;   // 右手トレイルの元の終了色
 
     void Awake()
     {
@@ -65,8 +69,16 @@ public class BoostController : MonoBehaviour
             rightOriginalColor = rightHandParticle.main.startColor.color;
         }
 
-        // トレイルの初期色を白に設定
-        SetTrailColor(Color.white, Color.white);
+        if (leftTrail != null)
+        {
+            leftTrailOriginalStartColor = leftTrail.startColor;
+            leftTrailOriginalEndColor = leftTrail.endColor;
+        }
+        if (rightTrail != null)
+        {
+            rightTrailOriginalStartColor = rightTrail.startColor;
+            rightTrailOriginalEndColor = rightTrail.endColor;
+        }
     }
 
     void Update()
@@ -133,7 +145,7 @@ public class BoostController : MonoBehaviour
         isBoosting = false;
         UpdateButtonColor();
         SetParticleColor(leftOriginalColor, rightOriginalColor);
-        SetTrailColor(Color.white, Color.white);
+        RestoreTrailColor();
     }
 
     private void UpdateBoostUI()
@@ -182,10 +194,26 @@ public class BoostController : MonoBehaviour
         if (leftTrail != null)
         {
             leftTrail.startColor = leftColor;
+            leftTrail.endColor = leftColor;
         }
         if (rightTrail != null)
         {
             rightTrail.startColor = rightColor;
+            rightTrail.endColor = rightColor;
+        }
+    }
+
+    private void RestoreTrailColor()
+    {
+        if (leftTrail != null)
+        {
+            leftTrail.startColor = leftTrailOriginalStartColor;
+            leftTrail.endColor = leftTrailOriginalEndColor;
+        }
+        if (rightTrail != null)
+        {
+            rightTrail.startColor = rightTrailOriginalStartColor;
+            rightTrail.endColor = rightTrailOriginalEndColor;
         }
     }
 


### PR DESCRIPTION
## Summary
- store the original trail colors so they can be restored after boosting ends
- set both the start and end colors of each trail renderer to yellow while boosting to achieve the requested effect

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_690916d795f88321b8ccc02685efe955