### PR TITLE
Fade spawn point when exiting GodRay collider

### DIFF
--- a/Assets/Musha/Prefab/Spawn_Point.prefab
+++ b/Assets/Musha/Prefab/Spawn_Point.prefab
@@ -11,6 +11,8 @@ GameObject:
   - component: {fileID: 2118948197}
   - component: {fileID: 2118948196}
   - component: {fileID: 2118948195}
+  - component: {fileID: 2118948198}
+  - component: {fileID: 2118948199}
   m_Layer: 0
   m_Name: GodRay
   m_TagString: Untagged
@@ -83,6 +85,34 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &2118948198
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2118948194}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &2118948199
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2118948194}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1f3b88fe5b5a4a579f4e4f2a4d1a4f40, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  spawnPointRoot: {fileID: 3418848500805181453}
+  fadeDuration: 1
+  targetTag: Player
 --- !u!1 &1985335231604110027
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GodRaySpawnPointFader.cs
+++ b/Assets/Scripts/GodRaySpawnPointFader.cs
@@ -1,0 +1,194 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[RequireComponent(typeof(Collider))]
+public class GodRaySpawnPointFader : MonoBehaviour
+{
+    [SerializeField] private GameObject spawnPointRoot;
+    [SerializeField] private float fadeDuration = 1f;
+    [SerializeField] private string targetTag = "Player";
+
+    private readonly List<Renderer> _renderers = new List<Renderer>();
+    private readonly List<ParticleSystem> _particleSystems = new List<ParticleSystem>();
+    private readonly List<Material> _materials = new List<Material>();
+    private readonly List<Color> _originalColors = new List<Color>();
+    private bool _isFading;
+    private Collider _collider;
+
+    private void Reset()
+    {
+        _collider = GetComponent<Collider>();
+        if (_collider != null)
+        {
+            _collider.isTrigger = true;
+        }
+
+        if (spawnPointRoot == null && transform.parent != null)
+        {
+            spawnPointRoot = transform.parent.gameObject;
+        }
+    }
+
+    private void Awake()
+    {
+        _collider = GetComponent<Collider>();
+        if (_collider != null && !_collider.isTrigger)
+        {
+            Debug.LogWarning($"{nameof(GodRaySpawnPointFader)} on {name} expects the collider to be marked as trigger.", this);
+        }
+
+        if (spawnPointRoot == null && transform.parent != null)
+        {
+            spawnPointRoot = transform.parent.gameObject;
+        }
+
+        if (spawnPointRoot == null)
+        {
+            Debug.LogWarning($"{nameof(GodRaySpawnPointFader)} on {name} has no spawn point assigned.", this);
+            return;
+        }
+
+        CacheSpawnPointRenderers();
+    }
+
+    private void CacheSpawnPointRenderers()
+    {
+        _renderers.Clear();
+        _particleSystems.Clear();
+        _materials.Clear();
+        _originalColors.Clear();
+
+        _renderers.AddRange(spawnPointRoot.GetComponentsInChildren<Renderer>(true));
+        _particleSystems.AddRange(spawnPointRoot.GetComponentsInChildren<ParticleSystem>(true));
+
+        foreach (var renderer in _renderers)
+        {
+            foreach (var material in renderer.materials)
+            {
+                if (TryGetColor(material, out var color))
+                {
+                    _materials.Add(material);
+                    _originalColors.Add(color);
+                }
+            }
+        }
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        HandleExit(other.gameObject);
+    }
+
+    private void OnCollisionExit(Collision collision)
+    {
+        HandleExit(collision.gameObject);
+    }
+
+    private void HandleExit(GameObject other)
+    {
+        if (_isFading || spawnPointRoot == null)
+        {
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(targetTag) && !other.CompareTag(targetTag))
+        {
+            return;
+        }
+
+        StartCoroutine(FadeOut());
+    }
+
+    private IEnumerator FadeOut()
+    {
+        _isFading = true;
+
+        float elapsed = 0f;
+        if (fadeDuration <= 0f)
+        {
+            ApplyAlpha(0f);
+            yield return null;
+        }
+        else
+        {
+            while (elapsed < fadeDuration)
+            {
+                float t = Mathf.Clamp01(elapsed / fadeDuration);
+                ApplyAlpha(1f - t);
+                elapsed += Time.deltaTime;
+                yield return null;
+            }
+            ApplyAlpha(0f);
+        }
+
+        foreach (var renderer in _renderers)
+        {
+            renderer.enabled = false;
+        }
+
+        foreach (var ps in _particleSystems)
+        {
+            if (ps != null)
+            {
+                ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+            }
+        }
+    }
+
+    private void ApplyAlpha(float normalizedAlpha)
+    {
+        for (int i = 0; i < _materials.Count; i++)
+        {
+            var originalColor = _originalColors[i];
+            var newColor = new Color(
+                originalColor.r,
+                originalColor.g,
+                originalColor.b,
+                originalColor.a * Mathf.Clamp01(normalizedAlpha));
+            SetColor(_materials[i], newColor);
+        }
+    }
+
+    private static bool TryGetColor(Material material, out Color color)
+    {
+        if (material == null)
+        {
+            color = default;
+            return false;
+        }
+
+        if (material.HasProperty("_BaseColor"))
+        {
+            color = material.GetColor("_BaseColor");
+            return true;
+        }
+
+        if (material.HasProperty("_Color"))
+        {
+            color = material.GetColor("_Color");
+            return true;
+        }
+
+        color = default;
+        return false;
+    }
+
+    private static void SetColor(Material material, Color color)
+    {
+        if (material == null)
+        {
+            return;
+        }
+
+        if (material.HasProperty("_BaseColor"))
+        {
+            material.SetColor("_BaseColor", color);
+        }
+
+        if (material.HasProperty("_Color"))
+        {
+            material.SetColor("_Color", color);
+        }
+    }
+}

--- a/Assets/Scripts/GodRaySpawnPointFader.cs.meta
+++ b/Assets/Scripts/GodRaySpawnPointFader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f3b88fe5b5a4a579f4e4f2a4d1a4f40
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add a GodRaySpawnPointFader component that fades the spawn point visuals when the player leaves the trigger
- update the Spawn_Point prefab so GodRay carries the trigger collider and new fade behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6909258f468483219601e9bd187b515a