### PR TITLE
Add quick slide lateral movement to drone controller

### DIFF
--- a/Assets/Musha/Prefab/Player.prefab
+++ b/Assets/Musha/Prefab/Player.prefab
@@ -1328,7 +1328,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rangeValue: 0.65
   allowedZone: 0
-  axisTypes: 2
+  axisTypes: 0
   snapX: 0
   snapY: 0
   holder: {fileID: 8566084810919288967}
@@ -1362,7 +1362,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   mobileController: {fileID: 3729987430627264143}
   enableDebugInput: 1
-  enableHorizontalInput: 0
+  enableHorizontalInput: 1
 --- !u!1 &7693951626014535107
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/RageRun Games/Easy Flying System/Prefabs/Controllers/Mobile/Drone Controller 3D (Mobile).prefab
+++ b/Assets/RageRun Games/Easy Flying System/Prefabs/Controllers/Mobile/Drone Controller 3D (Mobile).prefab
@@ -248,7 +248,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rangeValue: 0.65
   allowedZone: 0
-  axisTypes: 2
+  axisTypes: 0
   snapX: 0
   snapY: 0
   holder: {fileID: 785314489623078619}
@@ -282,7 +282,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   mobileController: {fileID: 5748480231206813907}
   enableDebugInput: 1
-  enableHorizontalInput: 0
+  enableHorizontalInput: 1
 --- !u!1 &1640242252333149087
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/RageRun Games/Easy Flying System/Scripts/DroneController.cs
+++ b/Assets/RageRun Games/Easy Flying System/Scripts/DroneController.cs
@@ -23,17 +23,7 @@ namespace RageRunGames.EasyFlyingSystem
         [Header("Quick Stop Settings")]
         [SerializeField] private float quickStopInputThreshold = 0.1f;
 
-        [Header("Quick Slide Settings")]
-        [SerializeField] private bool enableQuickSlide = true;
-        [SerializeField, Range(0f, 1f)] private float quickSlideActivationPitchThreshold = 0.4f;
-        [SerializeField, Range(0f, 1f)] private float quickSlideReleasePitchThreshold = 0.05f;
-        [SerializeField, Range(0f, 1f)] private float quickSlideInputThreshold = 0.25f;
-        [SerializeField] private float quickSlideWindowDuration = 0.25f;
-        [SerializeField] private float quickSlideVelocityChange = 2f;
-        [SerializeField] private float quickSlideDistance = 2f;
-        [SerializeField] private float quickSlideMinForwardSpeed = 1f;
-
-        [Header("Ground Settings")]
+        [Header("Ground Settings")] 
         [SerializeField] protected float groundCheckDistance = 0.2f;
 
         [SerializeField] protected bool decelerateOnGround;
@@ -47,14 +37,6 @@ namespace RageRunGames.EasyFlyingSystem
 
 
         private float timer;
-        private float previousPitchInput;
-        private float quickSlideTimer;
-        private bool quickSlideWindowActive;
-        private bool quickSlideMovementActive;
-        private float quickSlideMovementElapsed;
-        private float quickSlideMovementDuration;
-        private Vector3 quickSlideTargetOffset;
-        private Vector3 quickSlideAppliedOffset;
 
         private BaseInputHandler currentInputHandler;
         private BoostController boostController;
@@ -131,8 +113,6 @@ namespace RageRunGames.EasyFlyingSystem
                 disablePitch ? Vector3.zero : pitchInput * maxSpeed * transform.forward;
             float forwardSpeed = Vector3.Dot(rb.velocity, transform.forward);
 
-            HandleQuickSlide(pitchInput, inputHandler.Roll, inputHandler.Yaw, forwardSpeed);
-
             if (!IsBoosting() &&
                 Mathf.Abs(pitchInput) >= quickStopInputThreshold &&
                 ((forwardSpeed > 0f && pitchInput < 0f) ||
@@ -162,123 +142,12 @@ namespace RageRunGames.EasyFlyingSystem
             }
 
             rb.AddForce(forwardForce + liftForce + sidewaysForce, ForceMode.Force);
-            UpdateQuickSlideMovement();
             AdjustDrag(rb.velocity.magnitude);
-            previousPitchInput = pitchInput;
         }
 
         private bool IsBoosting()
         {
             return boostController != null && boostController.IsBoosting;
-        }
-
-        private void HandleQuickSlide(float pitchInput, float rollInput, float yawInput, float forwardSpeed)
-        {
-            if (!enableQuickSlide)
-            {
-                quickSlideWindowActive = false;
-                quickSlideTimer = 0f;
-                return;
-            }
-
-            if (!quickSlideWindowActive)
-            {
-                bool wasMovingForward = previousPitchInput > quickSlideActivationPitchThreshold;
-                bool hasReleasedForward = Mathf.Abs(pitchInput) <= quickSlideReleasePitchThreshold;
-                bool isMovingForward = forwardSpeed > quickSlideMinForwardSpeed;
-
-                if (wasMovingForward && hasReleasedForward && isMovingForward)
-                {
-                    quickSlideWindowActive = true;
-                    quickSlideTimer = quickSlideWindowDuration;
-                }
-            }
-            else
-            {
-                quickSlideTimer -= Time.deltaTime;
-
-                if (quickSlideTimer <= 0f)
-                {
-                    quickSlideWindowActive = false;
-                }
-                else
-                {
-                    float quickSlideAxis = Mathf.Abs(yawInput) >= quickSlideInputThreshold
-                        ? yawInput
-                        : Mathf.Abs(rollInput) >= quickSlideInputThreshold
-                            ? rollInput
-                            : 0f;
-
-                    if (Mathf.Abs(quickSlideAxis) >= quickSlideInputThreshold)
-                    {
-                        Vector3 slideDirection = Vector3.ProjectOnPlane(transform.right * Mathf.Sign(quickSlideAxis), Vector3.up);
-
-                        if (slideDirection.sqrMagnitude > 0f)
-                        {
-                            StartQuickSlide(slideDirection.normalized);
-                        }
-                    }
-                }
-            }
-        }
-
-        private void StartQuickSlide(Vector3 slideDirection)
-        {
-            quickSlideWindowActive = false;
-
-            if (quickSlideDistance <= 0f)
-            {
-                quickSlideMovementActive = false;
-                return;
-            }
-
-            quickSlideTargetOffset = slideDirection * quickSlideDistance;
-            quickSlideMovementDuration = quickSlideVelocityChange > Mathf.Epsilon
-                ? quickSlideDistance / quickSlideVelocityChange
-                : 0f;
-            quickSlideMovementElapsed = 0f;
-            quickSlideAppliedOffset = Vector3.zero;
-            quickSlideMovementActive = true;
-        }
-
-        private void UpdateQuickSlideMovement()
-        {
-            if (!quickSlideMovementActive)
-            {
-                return;
-            }
-
-            float deltaTime = Time.deltaTime;
-
-            if (quickSlideMovementDuration <= Mathf.Epsilon)
-            {
-                Vector3 remainingOffset = quickSlideTargetOffset - quickSlideAppliedOffset;
-
-                if (remainingOffset.sqrMagnitude > 0f)
-                {
-                    rb.MovePosition(rb.position + remainingOffset);
-                    quickSlideAppliedOffset += remainingOffset;
-                }
-
-                quickSlideMovementActive = false;
-                return;
-            }
-
-            quickSlideMovementElapsed += deltaTime;
-            float progress = Mathf.Clamp01(quickSlideMovementElapsed / quickSlideMovementDuration);
-            Vector3 desiredOffset = quickSlideTargetOffset * progress;
-            Vector3 offsetDelta = desiredOffset - quickSlideAppliedOffset;
-
-            if (offsetDelta.sqrMagnitude > 0f)
-            {
-                rb.MovePosition(rb.position + offsetDelta);
-                quickSlideAppliedOffset += offsetDelta;
-            }
-
-            if (progress >= 1f)
-            {
-                quickSlideMovementActive = false;
-            }
         }
 
         private void AdjustDrag(float speed)

--- a/Assets/RageRun Games/Easy Flying System/Scripts/DroneController.cs
+++ b/Assets/RageRun Games/Easy Flying System/Scripts/DroneController.cs
@@ -30,6 +30,7 @@ namespace RageRunGames.EasyFlyingSystem
         [SerializeField, Range(0f, 1f)] private float quickSlideInputThreshold = 0.25f;
         [SerializeField] private float quickSlideWindowDuration = 0.25f;
         [SerializeField] private float quickSlideVelocityChange = 2f;
+        [SerializeField] private float quickSlideDistance = 2f;
         [SerializeField] private float quickSlideMinForwardSpeed = 1f;
 
         [Header("Ground Settings")]
@@ -49,6 +50,11 @@ namespace RageRunGames.EasyFlyingSystem
         private float previousPitchInput;
         private float quickSlideTimer;
         private bool quickSlideWindowActive;
+        private bool quickSlideMovementActive;
+        private float quickSlideMovementElapsed;
+        private float quickSlideMovementDuration;
+        private Vector3 quickSlideTargetOffset;
+        private Vector3 quickSlideAppliedOffset;
 
         private BaseInputHandler currentInputHandler;
         private BoostController boostController;
@@ -156,6 +162,7 @@ namespace RageRunGames.EasyFlyingSystem
             }
 
             rb.AddForce(forwardForce + liftForce + sidewaysForce, ForceMode.Force);
+            UpdateQuickSlideMovement();
             AdjustDrag(rb.velocity.magnitude);
             previousPitchInput = pitchInput;
         }
@@ -200,12 +207,68 @@ namespace RageRunGames.EasyFlyingSystem
 
                     if (slideDirection.sqrMagnitude > 0f)
                     {
-                        slideDirection.Normalize();
-                        rb.AddForce(slideDirection * quickSlideVelocityChange, ForceMode.VelocityChange);
+                        StartQuickSlide(slideDirection.normalized);
                     }
-
-                    quickSlideWindowActive = false;
                 }
+            }
+        }
+
+        private void StartQuickSlide(Vector3 slideDirection)
+        {
+            quickSlideWindowActive = false;
+
+            if (quickSlideDistance <= 0f)
+            {
+                quickSlideMovementActive = false;
+                return;
+            }
+
+            quickSlideTargetOffset = slideDirection * quickSlideDistance;
+            quickSlideMovementDuration = quickSlideVelocityChange > Mathf.Epsilon
+                ? quickSlideDistance / quickSlideVelocityChange
+                : 0f;
+            quickSlideMovementElapsed = 0f;
+            quickSlideAppliedOffset = Vector3.zero;
+            quickSlideMovementActive = true;
+        }
+
+        private void UpdateQuickSlideMovement()
+        {
+            if (!quickSlideMovementActive)
+            {
+                return;
+            }
+
+            float deltaTime = Time.deltaTime;
+
+            if (quickSlideMovementDuration <= Mathf.Epsilon)
+            {
+                Vector3 remainingOffset = quickSlideTargetOffset - quickSlideAppliedOffset;
+
+                if (remainingOffset.sqrMagnitude > 0f)
+                {
+                    rb.MovePosition(rb.position + remainingOffset);
+                    quickSlideAppliedOffset += remainingOffset;
+                }
+
+                quickSlideMovementActive = false;
+                return;
+            }
+
+            quickSlideMovementElapsed += deltaTime;
+            float progress = Mathf.Clamp01(quickSlideMovementElapsed / quickSlideMovementDuration);
+            Vector3 desiredOffset = quickSlideTargetOffset * progress;
+            Vector3 offsetDelta = desiredOffset - quickSlideAppliedOffset;
+
+            if (offsetDelta.sqrMagnitude > 0f)
+            {
+                rb.MovePosition(rb.position + offsetDelta);
+                quickSlideAppliedOffset += offsetDelta;
+            }
+
+            if (progress >= 1f)
+            {
+                quickSlideMovementActive = false;
             }
         }
 

--- a/Assets/RageRun Games/Easy Flying System/Scripts/DroneController.cs
+++ b/Assets/RageRun Games/Easy Flying System/Scripts/DroneController.cs
@@ -23,7 +23,16 @@ namespace RageRunGames.EasyFlyingSystem
         [Header("Quick Stop Settings")]
         [SerializeField] private float quickStopInputThreshold = 0.1f;
 
-        [Header("Ground Settings")] 
+        [Header("Quick Slide Settings")]
+        [SerializeField] private bool enableQuickSlide = true;
+        [SerializeField, Range(0f, 1f)] private float quickSlideActivationPitchThreshold = 0.4f;
+        [SerializeField, Range(0f, 1f)] private float quickSlideReleasePitchThreshold = 0.05f;
+        [SerializeField, Range(0f, 1f)] private float quickSlideInputThreshold = 0.25f;
+        [SerializeField] private float quickSlideWindowDuration = 0.25f;
+        [SerializeField] private float quickSlideVelocityChange = 2f;
+        [SerializeField] private float quickSlideMinForwardSpeed = 1f;
+
+        [Header("Ground Settings")]
         [SerializeField] protected float groundCheckDistance = 0.2f;
 
         [SerializeField] protected bool decelerateOnGround;
@@ -37,6 +46,9 @@ namespace RageRunGames.EasyFlyingSystem
 
 
         private float timer;
+        private float previousPitchInput;
+        private float quickSlideTimer;
+        private bool quickSlideWindowActive;
 
         private BaseInputHandler currentInputHandler;
         private BoostController boostController;
@@ -113,6 +125,8 @@ namespace RageRunGames.EasyFlyingSystem
                 disablePitch ? Vector3.zero : pitchInput * maxSpeed * transform.forward;
             float forwardSpeed = Vector3.Dot(rb.velocity, transform.forward);
 
+            HandleQuickSlide(pitchInput, inputHandler.Roll, forwardSpeed);
+
             if (!IsBoosting() &&
                 Mathf.Abs(pitchInput) >= quickStopInputThreshold &&
                 ((forwardSpeed > 0f && pitchInput < 0f) ||
@@ -143,11 +157,56 @@ namespace RageRunGames.EasyFlyingSystem
 
             rb.AddForce(forwardForce + liftForce + sidewaysForce, ForceMode.Force);
             AdjustDrag(rb.velocity.magnitude);
+            previousPitchInput = pitchInput;
         }
 
         private bool IsBoosting()
         {
             return boostController != null && boostController.IsBoosting;
+        }
+
+        private void HandleQuickSlide(float pitchInput, float rollInput, float forwardSpeed)
+        {
+            if (!enableQuickSlide)
+            {
+                quickSlideWindowActive = false;
+                quickSlideTimer = 0f;
+                return;
+            }
+
+            if (!quickSlideWindowActive)
+            {
+                bool wasMovingForward = previousPitchInput > quickSlideActivationPitchThreshold;
+                bool hasReleasedForward = Mathf.Abs(pitchInput) <= quickSlideReleasePitchThreshold;
+                bool isMovingForward = forwardSpeed > quickSlideMinForwardSpeed;
+
+                if (wasMovingForward && hasReleasedForward && isMovingForward)
+                {
+                    quickSlideWindowActive = true;
+                    quickSlideTimer = quickSlideWindowDuration;
+                }
+            }
+            else
+            {
+                quickSlideTimer -= Time.deltaTime;
+
+                if (quickSlideTimer <= 0f)
+                {
+                    quickSlideWindowActive = false;
+                }
+                else if (Mathf.Abs(rollInput) >= quickSlideInputThreshold)
+                {
+                    Vector3 slideDirection = Vector3.ProjectOnPlane(transform.right * Mathf.Sign(rollInput), Vector3.up);
+
+                    if (slideDirection.sqrMagnitude > 0f)
+                    {
+                        slideDirection.Normalize();
+                        rb.AddForce(slideDirection * quickSlideVelocityChange, ForceMode.VelocityChange);
+                    }
+
+                    quickSlideWindowActive = false;
+                }
+            }
         }
 
         private void AdjustDrag(float speed)

--- a/Assets/RageRun Games/Easy Flying System/Scripts/DroneController.cs
+++ b/Assets/RageRun Games/Easy Flying System/Scripts/DroneController.cs
@@ -131,7 +131,7 @@ namespace RageRunGames.EasyFlyingSystem
                 disablePitch ? Vector3.zero : pitchInput * maxSpeed * transform.forward;
             float forwardSpeed = Vector3.Dot(rb.velocity, transform.forward);
 
-            HandleQuickSlide(pitchInput, inputHandler.Roll, forwardSpeed);
+            HandleQuickSlide(pitchInput, inputHandler.Roll, inputHandler.Yaw, forwardSpeed);
 
             if (!IsBoosting() &&
                 Mathf.Abs(pitchInput) >= quickStopInputThreshold &&
@@ -172,7 +172,7 @@ namespace RageRunGames.EasyFlyingSystem
             return boostController != null && boostController.IsBoosting;
         }
 
-        private void HandleQuickSlide(float pitchInput, float rollInput, float forwardSpeed)
+        private void HandleQuickSlide(float pitchInput, float rollInput, float yawInput, float forwardSpeed)
         {
             if (!enableQuickSlide)
             {
@@ -201,13 +201,22 @@ namespace RageRunGames.EasyFlyingSystem
                 {
                     quickSlideWindowActive = false;
                 }
-                else if (Mathf.Abs(rollInput) >= quickSlideInputThreshold)
+                else
                 {
-                    Vector3 slideDirection = Vector3.ProjectOnPlane(transform.right * Mathf.Sign(rollInput), Vector3.up);
+                    float quickSlideAxis = Mathf.Abs(yawInput) >= quickSlideInputThreshold
+                        ? yawInput
+                        : Mathf.Abs(rollInput) >= quickSlideInputThreshold
+                            ? rollInput
+                            : 0f;
 
-                    if (slideDirection.sqrMagnitude > 0f)
+                    if (Mathf.Abs(quickSlideAxis) >= quickSlideInputThreshold)
                     {
-                        StartQuickSlide(slideDirection.normalized);
+                        Vector3 slideDirection = Vector3.ProjectOnPlane(transform.right * Mathf.Sign(quickSlideAxis), Vector3.up);
+
+                        if (slideDirection.sqrMagnitude > 0f)
+                        {
+                            StartQuickSlide(slideDirection.normalized);
+                        }
                     }
                 }
             }

--- a/Assets/Scripts/KeyboardToJoystickDebug.cs
+++ b/Assets/Scripts/KeyboardToJoystickDebug.cs
@@ -9,7 +9,7 @@ namespace RageRunGames.EasyFlyingSystem
         [SerializeField] private bool enableDebugInput = true;      // デバッグ入力を有効化
         [SerializeField] private bool enableHorizontalInput = true; // 水平軸の入力を有効化
         private bool wasKeyboardInput = false; // 前フレームでキーボード入力があったか
-        private Vector2 lastKeyboardVector = Vector2.zero; // 前回適用したキーボード入力
+        private Vector2 lastAppliedKeyboardVector = Vector2.zero; // 前回適用したキーボード入力の寄与分
 
         private void Start()
         {
@@ -59,20 +59,20 @@ namespace RageRunGames.EasyFlyingSystem
                 }
             }
 
+            Vector2 baseInput = mobileController.CurrentInput - lastAppliedKeyboardVector;
+
             if (hasInput)
             {
-                Vector2 mobileInput = mobileController.CurrentInput - lastKeyboardVector;
                 Vector2 keyboardVector = new Vector2(horizontalInput, verticalInput);
-                lastKeyboardVector = keyboardVector;
-                Vector2 combined = Vector2.ClampMagnitude(mobileInput + keyboardVector, 1f);
+                Vector2 combined = Vector2.ClampMagnitude(baseInput + keyboardVector, 1f);
+                lastAppliedKeyboardVector = combined - baseInput;
                 mobileController.SetDebugInput(combined);
                 wasKeyboardInput = true;
             }
             else if (wasKeyboardInput)
             {
-                Vector2 mobileInput = mobileController.CurrentInput - lastKeyboardVector;
-                mobileController.SetDebugInput(mobileInput);
-                lastKeyboardVector = Vector2.zero;
+                mobileController.SetDebugInput(baseInput);
+                lastAppliedKeyboardVector = Vector2.zero;
                 wasKeyboardInput = false;
             }
         }


### PR DESCRIPTION
## Summary
- add configurable quick slide settings to the drone controller
- trigger a temporary quick slide window when forward input is released while moving
- apply a lateral velocity change when the player steers left or right during the quick slide window

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_690934c5b07c83219e87d87dd84acaa1