### PR TITLE
Refine drone flight controls for camera-relative touch input

### DIFF
--- a/Assets/RageRun Games/Easy Flying System/Scripts/DroneController.cs
+++ b/Assets/RageRun Games/Easy Flying System/Scripts/DroneController.cs
@@ -93,10 +93,9 @@ namespace RageRunGames.EasyFlyingSystem
         {
             base.HandleRotations();
 
-            Vector3 planarVel = currentPlanarVelocity;
             Vector3 yawRef = desiredPlanarDirection.sqrMagnitude > 0.0001f
                 ? desiredPlanarDirection
-                : (planarVel.sqrMagnitude > 0.25f ? planarVel.normalized : transform.forward);
+                : transform.forward;
 
             float targetYaw = Quaternion.LookRotation(yawRef, Vector3.up).eulerAngles.y;
             currentYaw = Mathf.LerpAngle(currentYaw, targetYaw, Time.deltaTime * turnResponsiveness);
@@ -120,12 +119,9 @@ namespace RageRunGames.EasyFlyingSystem
 
         protected override void UpdateMovement(IInputHandler inputHandler)
         {
-            Transform reference = headingReference;
-            if (reference == null)
-            {
-                Camera mainCam = Camera.main;
-                reference = mainCam != null ? mainCam.transform : transform;
-            }
+            Transform reference = headingReference != null
+                ? headingReference
+                : (Camera.main != null ? Camera.main.transform : transform);
 
             Vector2 planarInput = new Vector2(inputHandler.Roll, inputHandler.Pitch);
             if (disableRoll)

--- a/Assets/RageRun Games/Easy Flying System/Scripts/DroneController.cs
+++ b/Assets/RageRun Games/Easy Flying System/Scripts/DroneController.cs
@@ -2,6 +2,9 @@ using UnityEngine;
 
 namespace RageRunGames.EasyFlyingSystem
 {
+    // Tuning Notes: turnResponsiveness=6, bankAngleMax=35, bankReturnSpeed=3,
+    // acceleration=14, deceleration=10, maxPlanarSpeed=18,
+    // baseDrag=1.0, maxDrag=1.5, adjDragMaxSpeed=20
     [DisallowMultipleComponent]
     [RequireComponent(typeof(Rigidbody))]
     [RequireComponent(typeof(BoxCollider))]
@@ -10,9 +13,19 @@ namespace RageRunGames.EasyFlyingSystem
         [Header("Input Settings")] 
         [HideInInspector] public InputType inputType;
 
-        [Header("Controller Settings")] 
+        [Header("Controller Settings")]
         [SerializeField] private bool maintainAltitude = true;
         [SerializeField] protected bool useGravityOnNoInput;
+
+        [Header("Flight Control Settings")]
+        [SerializeField] private Transform headingReference;
+        [SerializeField] private float turnResponsiveness = 6f;
+        [SerializeField] private float bankAngleMax = 35f;
+        [SerializeField] private float bankReturnSpeed = 3f;
+        [SerializeField] private float acceleration = 14f;
+        [SerializeField] private float deceleration = 10f;
+        [SerializeField] private float maxPlanarSpeed = 18f;
+        [SerializeField] private float verticalLiftScale = 1f;
 
         [Header("Hover Settings")] 
         [SerializeField] protected bool enableHover;
@@ -40,6 +53,9 @@ namespace RageRunGames.EasyFlyingSystem
 
         private BaseInputHandler currentInputHandler;
         private BoostController boostController;
+        private Vector3 desiredPlanarDirection;
+        private Vector3 currentPlanarVelocity;
+        private Vector2 lastPlanarInput;
 
         public bool IsGrounded { get; private set; } = true;
 
@@ -77,9 +93,25 @@ namespace RageRunGames.EasyFlyingSystem
         {
             base.HandleRotations();
 
+            Vector3 planarVel = currentPlanarVelocity;
+            Vector3 yawRef = desiredPlanarDirection.sqrMagnitude > 0.0001f
+                ? desiredPlanarDirection
+                : (planarVel.sqrMagnitude > 0.25f ? planarVel.normalized : transform.forward);
+
+            float targetYaw = Quaternion.LookRotation(yawRef, Vector3.up).eulerAngles.y;
+            currentYaw = Mathf.LerpAngle(currentYaw, targetYaw, Time.deltaTime * turnResponsiveness);
+
+            float targetBank = Mathf.Clamp(lastPlanarInput.x * bankAngleMax, -bankAngleMax, bankAngleMax);
+            currentRoll = Mathf.Lerp(currentRoll, -targetBank, Time.deltaTime * bankReturnSpeed);
+
             if (autoForwardMovement)
             {
                 currentPitch = pitchAmount;
+            }
+            else
+            {
+                float pitchVisual = Mathf.Lerp(0f, 10f, Mathf.Abs(lastPlanarInput.y));
+                currentPitch = Mathf.Lerp(currentPitch, -Mathf.Sign(lastPlanarInput.y) * pitchVisual, Time.deltaTime * 3f);
             }
 
             Quaternion currentRotation = Quaternion.Euler(currentPitch, currentYaw, currentRoll);
@@ -88,6 +120,99 @@ namespace RageRunGames.EasyFlyingSystem
 
         protected override void UpdateMovement(IInputHandler inputHandler)
         {
+            Transform reference = headingReference;
+            if (reference == null)
+            {
+                Camera mainCam = Camera.main;
+                reference = mainCam != null ? mainCam.transform : transform;
+            }
+
+            Vector2 planarInput = new Vector2(inputHandler.Roll, inputHandler.Pitch);
+            if (disableRoll)
+            {
+                planarInput.x = 0f;
+            }
+            if (disablePitch)
+            {
+                planarInput.y = 0f;
+            }
+            lastPlanarInput = planarInput;
+
+            Vector3 camForward = reference.forward;
+            camForward.y = 0f;
+            if (camForward.sqrMagnitude < 0.0001f)
+            {
+                camForward = transform.forward;
+            }
+            camForward.Normalize();
+
+            Vector3 camRight = reference.right;
+            camRight.y = 0f;
+            if (camRight.sqrMagnitude < 0.0001f)
+            {
+                camRight = transform.right;
+            }
+            camRight.Normalize();
+
+            Vector3 desiredDir = camForward * planarInput.y + camRight * planarInput.x;
+            if (desiredDir.sqrMagnitude > 0.0001f)
+            {
+                desiredDir.Normalize();
+            }
+
+            float inputMagnitude = Mathf.Clamp01(planarInput.magnitude);
+            float targetSpeed = maxPlanarSpeed * inputMagnitude;
+            Vector3 desiredPlanarVel = desiredDir * targetSpeed;
+
+            if (autoForwardMovement)
+            {
+                Vector3 forwardPlanar = transform.forward;
+                forwardPlanar.y = 0f;
+                if (forwardPlanar.sqrMagnitude < 0.0001f)
+                {
+                    forwardPlanar = camForward;
+                }
+                forwardPlanar.Normalize();
+
+                Vector3 autoVelocity = forwardPlanar * maxPlanarSpeed;
+                Vector3 lateralVelocity = camRight * (planarInput.x * maxPlanarSpeed);
+                desiredPlanarVel = autoVelocity + lateralVelocity;
+
+                if (desiredPlanarVel.sqrMagnitude > maxPlanarSpeed * maxPlanarSpeed)
+                {
+                    desiredPlanarVel = desiredPlanarVel.normalized * maxPlanarSpeed;
+                }
+
+                desiredDir = desiredPlanarVel.sqrMagnitude > 0.0001f ? desiredPlanarVel.normalized : forwardPlanar;
+                inputMagnitude = 1f;
+            }
+
+            desiredPlanarDirection = desiredDir;
+
+            Vector3 velocity = rb.velocity;
+            Vector3 planarVelocity = new Vector3(velocity.x, 0f, velocity.z);
+            currentPlanarVelocity = planarVelocity;
+
+            float accel = inputMagnitude > 0.05f ? acceleration : deceleration;
+            Vector3 planarDelta = desiredPlanarVel - planarVelocity;
+            Vector3 planarAccel = Vector3.ClampMagnitude(planarDelta, accel);
+
+            if (maintainAltitude)
+            {
+                planarAccel.y = 0f;
+            }
+
+            rb.AddForce(planarAccel * rb.mass, ForceMode.Force);
+
+            float forwardSpeed = Vector3.Dot(rb.velocity, transform.forward);
+            if (!IsBoosting() &&
+                Mathf.Abs(inputHandler.Pitch) >= quickStopInputThreshold &&
+                ((forwardSpeed > 0f && inputHandler.Pitch < 0f) ||
+                 (forwardSpeed < 0f && inputHandler.Pitch > 0f)))
+            {
+                rb.velocity -= Vector3.Project(rb.velocity, transform.forward);
+            }
+
             Vector3 upVector = Vector3.up;
             upVector.x = 0f;
             upVector.z = 0f;
@@ -95,44 +220,18 @@ namespace RageRunGames.EasyFlyingSystem
             float upVectorMagnitude = 1 - upVector.magnitude;
             float gravityMagnitude = Physics.gravity.magnitude * upVectorMagnitude;
 
-            float upwardForce = 0f;
+            float upwardForce;
 
             if (!useGravityOnNoInput)
             {
-                upwardForce = rb.mass * Physics.gravity.magnitude + gravityMagnitude + inputHandler.Lift * maxSpeed;
+                upwardForce = rb.mass * Physics.gravity.magnitude + gravityMagnitude + inputHandler.Lift * maxSpeed * verticalLiftScale;
             }
             else
             {
-                upwardForce = inputHandler.Lift * maxSpeed;
+                upwardForce = inputHandler.Lift * maxSpeed * verticalLiftScale;
             }
 
             Vector3 liftForce = Vector3.up * upwardForce;
-
-            float pitchInput = inputHandler.Pitch;
-            Vector3 forwardForce =
-                disablePitch ? Vector3.zero : pitchInput * maxSpeed * transform.forward;
-            float forwardSpeed = Vector3.Dot(rb.velocity, transform.forward);
-
-            if (!IsBoosting() &&
-                Mathf.Abs(pitchInput) >= quickStopInputThreshold &&
-                ((forwardSpeed > 0f && pitchInput < 0f) ||
-                 (forwardSpeed < 0f && pitchInput > 0f)))
-            {
-                rb.velocity -= Vector3.Project(rb.velocity, transform.forward);
-            }
-            Vector3 sidewaysForce =
-                disableRoll ? Vector3.zero : inputHandler.Roll * maxSpeed * transform.right;
-
-            if (autoForwardMovement)
-            {
-                forwardForce = maxSpeed * transform.forward;
-            }
-
-            if (maintainAltitude)
-            {
-                forwardForce.y = 0f;
-                sidewaysForce.y = 0f;
-            }
 
             if (enableHover && inputHandler.checkInputs)
             {
@@ -141,7 +240,7 @@ namespace RageRunGames.EasyFlyingSystem
                 liftForce += Vector3.up * hoverForce;
             }
 
-            rb.AddForce(forwardForce + liftForce + sidewaysForce, ForceMode.Force);
+            rb.AddForce(liftForce, ForceMode.Force);
             AdjustDrag(rb.velocity.magnitude);
         }
 
@@ -154,9 +253,6 @@ namespace RageRunGames.EasyFlyingSystem
         {
             // 速度に応じて抗力を線形補間
             rb.drag = Mathf.Lerp(baseDrag, maxDrag, speed / adjDragMaxSpeed);
-
-            // デバッグログ
-            Debug.Log($"Speed: {speed}, Drag: {rb.drag}");
         }
 
         public InputType GetInputType()

--- a/Assets/RageRun Games/Easy Flying System/Scripts/DroneController.cs
+++ b/Assets/RageRun Games/Easy Flying System/Scripts/DroneController.cs
@@ -71,6 +71,7 @@ namespace RageRunGames.EasyFlyingSystem
             // 抗力の初期値を設定
             rb.drag = baseDrag;
             boostController = GetComponent<BoostController>();
+            desiredPlanarDirection = transform.forward;
         }
 
         protected override void Update()
@@ -95,7 +96,7 @@ namespace RageRunGames.EasyFlyingSystem
 
             Vector3 yawRef = desiredPlanarDirection.sqrMagnitude > 0.0001f
                 ? desiredPlanarDirection
-                : transform.forward;
+                : (currentPlanarVelocity.sqrMagnitude > 0.25f ? currentPlanarVelocity.normalized : transform.forward);
 
             float targetYaw = Quaternion.LookRotation(yawRef, Vector3.up).eulerAngles.y;
             currentYaw = Mathf.LerpAngle(currentYaw, targetYaw, Time.deltaTime * turnResponsiveness);
@@ -183,11 +184,18 @@ namespace RageRunGames.EasyFlyingSystem
                 inputMagnitude = 1f;
             }
 
-            desiredPlanarDirection = desiredDir;
-
             Vector3 velocity = rb.velocity;
             Vector3 planarVelocity = new Vector3(velocity.x, 0f, velocity.z);
             currentPlanarVelocity = planarVelocity;
+
+            if (desiredDir.sqrMagnitude > 0.0001f)
+            {
+                desiredPlanarDirection = desiredDir;
+            }
+            else if (planarVelocity.sqrMagnitude > 0.25f)
+            {
+                desiredPlanarDirection = planarVelocity.normalized;
+            }
 
             float accel = inputMagnitude > 0.05f ? acceleration : deceleration;
             Vector3 planarDelta = desiredPlanarVel - planarVelocity;

--- a/Assets/Scripts/LunaraRotationReset.cs
+++ b/Assets/Scripts/LunaraRotationReset.cs
@@ -1,24 +1,12 @@
 using UnityEngine;
 
 /// <summary>
-/// Player配下のLunaraオブジェクトのローカルRotationを徐々に0へ戻す。
+/// Lunaraのローカル回転を自動で元に戻さず、そのまま保持する。
 /// </summary>
 public class LunaraRotationReset : MonoBehaviour
 {
-    [Tooltip("1秒間に戻る角度(度)。値が大きいほど早く0に戻ります。")]
-    public float returnSpeed = 360f; // 1秒間に360度で元に戻す
-
     void Update()
     {
-        // ローカル回転が0以外なら徐々にQuaternion.identityへ近づける
-        if (transform.localRotation != Quaternion.identity)
-        {
-            transform.localRotation = Quaternion.RotateTowards(
-                transform.localRotation,
-                Quaternion.identity,
-                returnSpeed * Time.deltaTime
-            );
-        }
     }
 }
 

--- a/Assets/Scripts/LunaraRotationReset.cs
+++ b/Assets/Scripts/LunaraRotationReset.cs
@@ -1,12 +1,24 @@
 using UnityEngine;
 
 /// <summary>
-/// Lunaraのローカル回転を自動で元に戻さず、そのまま保持する。
+/// Player配下のLunaraオブジェクトのローカルRotationを徐々に0へ戻す。
 /// </summary>
 public class LunaraRotationReset : MonoBehaviour
 {
+    [Tooltip("1秒間に戻る角度(度)。値が大きいほど早く0に戻ります。")]
+    public float returnSpeed = 360f; // 1秒間に360度で元に戻す
+
     void Update()
     {
+        // ローカル回転が0以外なら徐々にQuaternion.identityへ近づける
+        if (transform.localRotation != Quaternion.identity)
+        {
+            transform.localRotation = Quaternion.RotateTowards(
+                transform.localRotation,
+                Quaternion.identity,
+                returnSpeed * Time.deltaTime
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add inspector-driven flight tuning fields and camera-relative heading fallback
- refactor planar movement toward desired velocity with acceleration/deceleration control while keeping existing lift and hover logic
- update rotation handling for auto-yaw, banking, and touch-friendly pitch visuals

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dd3ca910c8321a3dde567cdcd5b88)