### PR TITLE
Fix PlayerControls input integration and resolve compile errors

### DIFF
--- a/Assets/Scripts/Controls/MobileInput.cs
+++ b/Assets/Scripts/Controls/MobileInput.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
+using RageRunGames.EasyFlyingSystem;
 
 public class MobileInput : MonoBehaviour
 {
@@ -7,12 +8,24 @@ public class MobileInput : MonoBehaviour
     public bool isForward;
     public bool boost;
 
+    [SerializeField] private MobileController mobileController;
+    [SerializeField, Range(0.001f, 0.1f)] private float pointerSensitivity = 0.01f;
+
+    private float horizontalValue;
+
     // PlayerInput が自動で呼ぶメソッド
     public void OnPitchRollYaw(InputAction.CallbackContext ctx)
-        => drag = ctx.ReadValue<Vector2>();
+    {
+        drag = ctx.ReadValue<Vector2>();
+        horizontalValue = Mathf.Clamp(horizontalValue + drag.x * pointerSensitivity, -1f, 1f);
+        UpdateControllerInput();
+    }
 
     public void OnMoveForward(InputAction.CallbackContext ctx)
-        => isForward = ctx.ReadValueAsButton();
+    {
+        isForward = ctx.ReadValueAsButton();
+        UpdateControllerInput();
+    }
 
     public void OnBoost(InputAction.CallbackContext ctx)
     {
@@ -20,5 +33,31 @@ public class MobileInput : MonoBehaviour
             boost = true;
         if (ctx.canceled)
             boost = false;
+    }
+
+    private void Awake()
+    {
+        if (mobileController == null)
+        {
+            mobileController = FindFirstObjectByType<MobileController>();
+        }
+
+        if (mobileController != null)
+        {
+            mobileController.UseUnityInputFallback = false;
+            UpdateControllerInput();
+        }
+    }
+
+    private void UpdateControllerInput()
+    {
+        if (mobileController == null)
+        {
+            return;
+        }
+
+        float forwardValue = isForward ? 1f : 0f;
+        Vector2 baseInput = new Vector2(horizontalValue, forwardValue);
+        mobileController.SetBaseInput(baseInput);
     }
 }

--- a/Assets/Scripts/KeyboardToJoystickDebug.cs
+++ b/Assets/Scripts/KeyboardToJoystickDebug.cs
@@ -7,12 +7,21 @@ namespace RageRunGames.EasyFlyingSystem
     {
         [SerializeField] private bool enableDebugInput = true;      // デバッグ入力を有効化
         [SerializeField] private bool enableHorizontalInput = true; // 水平軸の入力を有効化
+        [SerializeField] private MobileController mobileController; // 実際の入力を管理する MobileController
         private bool wasKeyboardInput = false; // 前フレームでキーボード入力があったか
         private Vector2 lastAppliedKeyboardVector = Vector2.zero; // 前回適用したキーボード入力の寄与分
 
-        private void Start()
+        private void Awake()
         {
+            if (mobileController == null)
+            {
+                mobileController = GetComponent<MobileController>();
+            }
 
+            if (mobileController == null)
+            {
+                mobileController = GetComponentInChildren<MobileController>();
+            }
         }
 
         private void Update()
@@ -50,18 +59,20 @@ namespace RageRunGames.EasyFlyingSystem
                 }
             }
 
-            Vector2 baseInput = CurrentInput - lastAppliedKeyboardVector;
+            Vector2 baseInput = mobileController.CurrentInput - lastAppliedKeyboardVector;
 
             if (hasInput)
             {
                 Vector2 keyboardVector = new Vector2(horizontalInput, verticalInput);
                 Vector2 combined = Vector2.ClampMagnitude(baseInput + keyboardVector, 1f);
                 lastAppliedKeyboardVector = combined - baseInput;
+                mobileController.SetDebugInput(combined);
                 wasKeyboardInput = true;
             }
             else if (wasKeyboardInput)
             {
                 lastAppliedKeyboardVector = Vector2.zero;
+                mobileController.ClearDebugInput();
                 wasKeyboardInput = false;
             }
         }

--- a/Assets/Scripts/MobileController.cs
+++ b/Assets/Scripts/MobileController.cs
@@ -16,6 +16,15 @@ namespace RageRunGames.EasyFlyingSystem
         private Vector2 debugContribution;
 
         /// <summary>
+        /// Determines whether the legacy Unity input axes should be sampled when no other input provider is used.
+        /// </summary>
+        public bool UseUnityInputFallback
+        {
+            get => useUnityInputFallback;
+            set => useUnityInputFallback = value;
+        }
+
+        /// <summary>
         /// Current input vector after combining base input and debug contribution.
         /// </summary>
         public Vector2 CurrentInput => Vector2.ClampMagnitude(baseInput + debugContribution, 1f);

--- a/Assets/Scripts/ScoreManager.cs
+++ b/Assets/Scripts/ScoreManager.cs
@@ -26,7 +26,6 @@ public class ScoreManager : MonoBehaviour
 
     private int keyCount = 0;
     private int score = 0;
-    private int lastSpawnScore = 0;
     private int chainCount = 0;
     private float lastItemTime;
     public float chainTime = 0.5f;
@@ -89,12 +88,7 @@ public class ScoreManager : MonoBehaviour
             chainTextVertical.gameObject.SetActive(false);
         }
 
-        // スコアが閾値を超える場合にオブジェクトをスポーン
-        // if (score - lastSpawnScore >= 1000)
-        // {
-        //     lastSpawnScore = score;
-        //     objectSpawner.SpawnObject();
-        // }
+        // スコアが一定量増加した際にスポーンさせたい場合は、前回スポーン時のスコアを別途保持して判定する
 
         // スコアが特定の閾値を超える場合にオブジェクトをスポーン
         for (int i = 0; i < scoreThresholds.Length; i++)

--- a/Assets/Scripts/TimerController.cs
+++ b/Assets/Scripts/TimerController.cs
@@ -15,6 +15,15 @@ public class TimerController : MonoBehaviour
     public GameObject resultVertical; // 縦向きのときに表示するゲームオーバー画面
     public GameObject resultHorizontal; // 横向きのときに表示するゲームオーバー画面
     [SerializeField] private ScoreManager scoreManager; // ScoreManagerへの参照
+    [SerializeField] private DroneController droneController; // ゲーム中の操作を行う DroneController
+
+    private void Awake()
+    {
+        if (droneController == null)
+        {
+            droneController = FindObjectOfType<DroneController>();
+        }
+    }
 
     void Start()
     {


### PR DESCRIPTION
## Summary
- hook KeyboardToJoystickDebug into MobileController so debug input applies correctly
- allow TimerController to locate and disable the active DroneController at game over and remove unused score state
- wire the PlayerControls input map through MobileInput and MobileController, adding an API to disable legacy axis fallback

## Testing
- not run (Unity editor)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f1d73fc988321917edb92e03a574c)