### PR TITLE
Add boost FOV adjustment and forward inertia

### DIFF
--- a/Assets/Scripts/Controls/PlayerController.cs
+++ b/Assets/Scripts/Controls/PlayerController.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
+using Cinemachine;
 
 public class PlayerController : MonoBehaviour
 {
@@ -12,6 +13,12 @@ public class PlayerController : MonoBehaviour
     public float yawFactor   = 90f;
     public float pitchFactor = 90f;
 
+    [Header("Forward Inertia")]
+    [Tooltip("前進を止めた後に慣性として維持する時間（秒）")]
+    public float inertiaDuration = 0.35f;
+    [Tooltip("慣性の減速カーブ（X=経過割合 0-1, Y=速度倍率）")]
+    public AnimationCurve inertiaSpeedCurve = AnimationCurve.EaseInOut(0f, 1f, 1f, 0f);
+
     [Header("Gentle Fall (前進停止後の自然落下)")]
     public float fallDelaySeconds = 0.5f;   // 何秒後に落下開始
     public float fallAccel        = 2.0f;   // 落下加速度(擬似)
@@ -20,12 +27,19 @@ public class PlayerController : MonoBehaviour
     [Header("Refs")]
     public BoostController boost;   // ← BoostController をドラッグで割り当て
     public Animator animator;       // 任意
+    [SerializeField] private CinemachineVirtualCamera virtualCamera;
+    [SerializeField] private float boostFovIncrease = 5f;
 
     // runtime state
     private bool forwardHeld;
     private Vector2 drag;
     private float timeSinceForwardReleased = 0f;
     private float verticalVel = 0f; // 自然落下用（Rigidbody非使用の簡易実装）
+    private float inertiaTimer = 0f;
+    private Vector3 inertiaDirection = Vector3.forward;
+    private float inertiaSpeed = 0f;
+    private float defaultCameraFov;
+    private bool cameraFovCached;
 
     void OnEnable()
     {
@@ -45,12 +59,29 @@ public class PlayerController : MonoBehaviour
         // 速度決定：BoostController の倍率を採用
         float speedMul = (boost != null) ? boost.CurrentSpeedMultiplier : 1f;
         float speed    = normalSpeed * speedMul;
+        bool isBoosting = boost && boost.IsBoosting;
+
+        if (!virtualCamera && boostFovIncrease != 0f)
+        {
+            // 保険で開始時に取得できなかった場合に探して記録
+            virtualCamera = GetComponentInChildren<CinemachineVirtualCamera>();
+        }
+        if (virtualCamera)
+        {
+            if (!cameraFovCached)
+            {
+                defaultCameraFov = virtualCamera.m_Lens.FieldOfView;
+                cameraFovCached = true;
+            }
+            virtualCamera.m_Lens.FieldOfView = defaultCameraFov + (isBoosting ? boostFovIncrease : 0f);
+        }
 
         // アニメーター
         if (animator)
         {
-            animator.SetBool("IsFlying",   forwardHeld);
-            if (boost) animator.SetBool("IsBoosting", boost.IsBoosting);
+            bool isFlying = forwardHeld || inertiaTimer > 0f;
+            animator.SetBool("IsFlying",   isFlying);
+            if (boost) animator.SetBool("IsBoosting", isBoosting);
         }
 
         // 前進
@@ -61,22 +92,38 @@ public class PlayerController : MonoBehaviour
             // 前進中は落下リセット
             timeSinceForwardReleased = 0f;
             verticalVel = 0f;
+            inertiaTimer = 0f;
         }
         else
         {
-            // 停止してからの経過
-            timeSinceForwardReleased += Time.deltaTime;
-
-            // 遅延後にゆっくり自然落下（Rigidbodyなし版）
-            if (timeSinceForwardReleased >= fallDelaySeconds)
+            if (inertiaTimer > 0f)
             {
-                // v = v + a*dt（下向きを負方向とする）
-                verticalVel = Mathf.MoveTowards(
-                    verticalVel,
-                    -maxFallSpeed,
-                    fallAccel * Time.deltaTime
-                );
-                transform.position += Vector3.up * verticalVel * Time.deltaTime;
+                float normalizedTime = 1f - (inertiaTimer / Mathf.Max(inertiaDuration, Mathf.Epsilon));
+                float curve = inertiaSpeedCurve != null
+                    ? inertiaSpeedCurve.Evaluate(Mathf.Clamp01(normalizedTime))
+                    : 1f;
+                transform.position += inertiaDirection * (inertiaSpeed * curve) * Time.deltaTime;
+                inertiaTimer = Mathf.Max(0f, inertiaTimer - Time.deltaTime);
+
+                timeSinceForwardReleased = 0f;
+                verticalVel = 0f;
+            }
+            else
+            {
+                // 停止してからの経過
+                timeSinceForwardReleased += Time.deltaTime;
+
+                // 遅延後にゆっくり自然落下（Rigidbodyなし版）
+                if (timeSinceForwardReleased >= fallDelaySeconds)
+                {
+                    // v = v + a*dt（下向きを負方向とする）
+                    verticalVel = Mathf.MoveTowards(
+                        verticalVel,
+                        -maxFallSpeed,
+                        fallAccel * Time.deltaTime
+                    );
+                    transform.position += Vector3.up * verticalVel * Time.deltaTime;
+                }
             }
         }
 
@@ -91,7 +138,18 @@ public class PlayerController : MonoBehaviour
     // ---- callbacks ----
     private void OnForward(InputAction.CallbackContext ctx)
     {
-        forwardHeld = ctx.ReadValueAsButton();
+        bool pressed = ctx.ReadValueAsButton();
+
+        if (!pressed && forwardHeld)
+        {
+            BeginInertia();
+        }
+        else if (pressed)
+        {
+            inertiaTimer = 0f;
+        }
+
+        forwardHeld = pressed;
     }
     private void OnDrag(InputAction.CallbackContext ctx)
     {
@@ -115,5 +173,33 @@ public class PlayerController : MonoBehaviour
         r.action.performed -= cb;
         r.action.canceled  -= cb;
         r.action.Disable();
+    }
+
+    private void BeginInertia()
+    {
+        if (inertiaDuration <= 0f)
+        {
+            inertiaTimer = 0f;
+            return;
+        }
+
+        inertiaTimer = inertiaDuration;
+        inertiaDirection = transform.forward;
+        float speedMul = (boost != null) ? boost.CurrentSpeedMultiplier : 1f;
+        inertiaSpeed = normalSpeed * speedMul;
+    }
+
+    void Awake()
+    {
+        if (!virtualCamera)
+        {
+            virtualCamera = GetComponentInChildren<CinemachineVirtualCamera>();
+        }
+
+        if (virtualCamera)
+        {
+            defaultCameraFov = virtualCamera.m_Lens.FieldOfView;
+            cameraFovCached = true;
+        }
     }
 }

--- a/Assets/Scripts/Controls/PlayerController.cs
+++ b/Assets/Scripts/Controls/PlayerController.cs
@@ -29,6 +29,7 @@ public class PlayerController : MonoBehaviour
     public Animator animator;       // 任意
     [SerializeField] private CinemachineVirtualCamera virtualCamera;
     [SerializeField] private float boostFovIncrease = 5f;
+    [SerializeField] private float boostFovAdjustSpeed = 10f;
 
     // runtime state
     private bool forwardHeld;
@@ -73,7 +74,12 @@ public class PlayerController : MonoBehaviour
                 defaultCameraFov = virtualCamera.m_Lens.FieldOfView;
                 cameraFovCached = true;
             }
-            virtualCamera.m_Lens.FieldOfView = defaultCameraFov + (isBoosting ? boostFovIncrease : 0f);
+            float targetFov = defaultCameraFov + (isBoosting ? boostFovIncrease : 0f);
+            float currentFov = virtualCamera.m_Lens.FieldOfView;
+            float newFov = (boostFovAdjustSpeed > 0f)
+                ? Mathf.MoveTowards(currentFov, targetFov, boostFovAdjustSpeed * Time.deltaTime)
+                : targetFov;
+            virtualCamera.m_Lens.FieldOfView = newFov;
         }
 
         // アニメーター


### PR DESCRIPTION
## Summary
- cache the default Cinemachine virtual camera FOV and raise it while boost is active
- add configurable forward inertia so the flying animation eases into idle after releasing forward input

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f4511b8a48321b4bf67987c0cc1f4)