### PR TITLE
Adjust boost gauge visibility and layout

### DIFF
--- a/Assets/Scripts/BoostController.cs
+++ b/Assets/Scripts/BoostController.cs
@@ -53,7 +53,7 @@ public class BoostController : MonoBehaviour
 
         ConfigureBoostUI();
         UpdateBoostUI();
-        SetBoostUIVisibility(isBoosting);
+        SetBoostUIVisibility(ShouldShowBoostUI());
     }
 
     private void OnDisable()
@@ -89,6 +89,7 @@ public class BoostController : MonoBehaviour
         }
 
         UpdateBoostUI();
+        SetBoostUIVisibility(ShouldShowBoostUI());
     }
 
     private void OnBoostPerformed(InputAction.CallbackContext ctx)
@@ -103,14 +104,14 @@ public class BoostController : MonoBehaviour
         if (currentBoost <= 0f) return;
         isBoosting = true;
         SetFXColor(Color.yellow, Color.yellow);
-        SetBoostUIVisibility(true);
+        SetBoostUIVisibility(ShouldShowBoostUI());
     }
 
     public void DisableBoost()
     {
         isBoosting = false;
         SetFXColor(leftOriginalColor, rightOriginalColor);
-        SetBoostUIVisibility(false);
+        SetBoostUIVisibility(ShouldShowBoostUI());
     }
 
     public void ToggleBoost()  // UIボタンからも呼べるように
@@ -123,6 +124,7 @@ public class BoostController : MonoBehaviour
     {
         currentBoost = Mathf.Clamp(currentBoost + Mathf.Abs(amount), 0f, maxBoost);
         UpdateBoostUI();
+        SetBoostUIVisibility(ShouldShowBoostUI());
     }
 
     private void UpdateBoostUI()
@@ -154,23 +156,23 @@ public class BoostController : MonoBehaviour
         if (rect)
         {
             rect.anchorMin = rect.anchorMax = new Vector2(0.5f, 0.5f);
-            rect.anchoredPosition = new Vector2(120f, 0f);
-            rect.sizeDelta = new Vector2(40f, 200f);
+            rect.anchoredPosition = new Vector2(90f, 0f);
+            rect.sizeDelta = new Vector2(18f, 140f);
         }
 
         RectTransform fillArea = slider.transform.Find("Fill Area") as RectTransform;
         if (fillArea)
         {
-            fillArea.anchorMin = new Vector2(0.2f, 0f);
-            fillArea.anchorMax = new Vector2(0.8f, 1f);
+            fillArea.anchorMin = new Vector2(0.25f, 0f);
+            fillArea.anchorMax = new Vector2(0.75f, 1f);
             fillArea.sizeDelta = Vector2.zero;
         }
 
         RectTransform background = slider.transform.Find("Background") as RectTransform;
         if (background)
         {
-            background.anchorMin = new Vector2(0.2f, 0f);
-            background.anchorMax = new Vector2(0.8f, 1f);
+            background.anchorMin = new Vector2(0.25f, 0f);
+            background.anchorMax = new Vector2(0.75f, 1f);
             background.sizeDelta = Vector2.zero;
         }
 
@@ -187,8 +189,8 @@ public class BoostController : MonoBehaviour
         {
             label.anchorMin = label.anchorMax = new Vector2(1f, 0.5f);
             label.pivot = new Vector2(0f, 0.5f);
-            label.anchoredPosition = new Vector2(30f, 0f);
-            label.sizeDelta = new Vector2(80f, 30f);
+            label.anchoredPosition = new Vector2(24f, 0f);
+            label.sizeDelta = new Vector2(70f, 24f);
 
             TextMeshProUGUI labelText = label.GetComponent<TextMeshProUGUI>();
             if (labelText)
@@ -197,6 +199,11 @@ public class BoostController : MonoBehaviour
                 labelText.enableWordWrapping = false;
             }
         }
+    }
+
+    private bool ShouldShowBoostUI()
+    {
+        return isBoosting || currentBoost < maxBoost;
     }
 
     private void SetBoostUIVisibility(bool visible)

--- a/Assets/Scripts/BoostController.cs
+++ b/Assets/Scripts/BoostController.cs
@@ -1,3 +1,4 @@
+using TMPro;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.UI;
@@ -50,7 +51,9 @@ public class BoostController : MonoBehaviour
         if (leftHandParticle)  leftOriginalColor  = leftHandParticle.main.startColor.color;
         if (rightHandParticle) rightOriginalColor = rightHandParticle.main.startColor.color;
 
+        ConfigureBoostUI();
         UpdateBoostUI();
+        SetBoostUIVisibility(isBoosting);
     }
 
     private void OnDisable()
@@ -60,6 +63,8 @@ public class BoostController : MonoBehaviour
             boostAction.action.performed -= OnBoostPerformed;
             boostAction.action.Disable();
         }
+
+        SetBoostUIVisibility(false);
     }
 
     private void Update()
@@ -98,12 +103,14 @@ public class BoostController : MonoBehaviour
         if (currentBoost <= 0f) return;
         isBoosting = true;
         SetFXColor(Color.yellow, Color.yellow);
+        SetBoostUIVisibility(true);
     }
 
     public void DisableBoost()
     {
         isBoosting = false;
         SetFXColor(leftOriginalColor, rightOriginalColor);
+        SetBoostUIVisibility(false);
     }
 
     public void ToggleBoost()  // UIボタンからも呼べるように
@@ -121,8 +128,93 @@ public class BoostController : MonoBehaviour
     private void UpdateBoostUI()
     {
         float v = (maxBoost <= 0f) ? 0f : currentBoost / maxBoost;
-        if (boostBarVertical)   boostBarVertical.value = v;
-        if (boostBarHorizontal) boostBarHorizontal.value = v;
+        if (boostBarVertical)
+        {
+            boostBarVertical.value = v;
+        }
+        if (boostBarHorizontal)
+        {
+            boostBarHorizontal.value = v;
+        }
+    }
+
+    private void ConfigureBoostUI()
+    {
+        ConfigureBoostSlider(boostBarVertical);
+        ConfigureBoostSlider(boostBarHorizontal);
+    }
+
+    private void ConfigureBoostSlider(Slider slider)
+    {
+        if (!slider) return;
+
+        slider.direction = Slider.Direction.BottomToTop;
+
+        RectTransform rect = slider.GetComponent<RectTransform>();
+        if (rect)
+        {
+            rect.anchorMin = rect.anchorMax = new Vector2(0.5f, 0.5f);
+            rect.anchoredPosition = new Vector2(120f, 0f);
+            rect.sizeDelta = new Vector2(40f, 200f);
+        }
+
+        RectTransform fillArea = slider.transform.Find("Fill Area") as RectTransform;
+        if (fillArea)
+        {
+            fillArea.anchorMin = new Vector2(0.2f, 0f);
+            fillArea.anchorMax = new Vector2(0.8f, 1f);
+            fillArea.sizeDelta = Vector2.zero;
+        }
+
+        RectTransform background = slider.transform.Find("Background") as RectTransform;
+        if (background)
+        {
+            background.anchorMin = new Vector2(0.2f, 0f);
+            background.anchorMax = new Vector2(0.8f, 1f);
+            background.sizeDelta = Vector2.zero;
+        }
+
+        if (slider.fillRect)
+        {
+            RectTransform fill = slider.fillRect;
+            fill.anchorMin = new Vector2(0f, 0f);
+            fill.anchorMax = new Vector2(1f, 1f);
+            fill.pivot = new Vector2(0.5f, 0f);
+        }
+
+        RectTransform label = slider.transform.Find("Text (TMP)") as RectTransform;
+        if (label)
+        {
+            label.anchorMin = label.anchorMax = new Vector2(1f, 0.5f);
+            label.pivot = new Vector2(0f, 0.5f);
+            label.anchoredPosition = new Vector2(30f, 0f);
+            label.sizeDelta = new Vector2(80f, 30f);
+
+            TextMeshProUGUI labelText = label.GetComponent<TextMeshProUGUI>();
+            if (labelText)
+            {
+                labelText.alignment = TextAlignmentOptions.Left;
+                labelText.enableWordWrapping = false;
+            }
+        }
+    }
+
+    private void SetBoostUIVisibility(bool visible)
+    {
+        if (boostBarVertical)
+        {
+            if (boostBarVertical.gameObject.activeSelf != visible)
+            {
+                boostBarVertical.gameObject.SetActive(visible);
+            }
+        }
+        if (boostBarHorizontal)
+        {
+            if (boostBarHorizontal.gameObject.activeSelf != visible)
+            {
+                boostBarHorizontal.gameObject.SetActive(visible);
+            }
+        }
     }
 
     private void SetFXColor(Color leftColor, Color rightColor)

--- a/Assets/Scripts/BoostController.cs
+++ b/Assets/Scripts/BoostController.cs
@@ -9,6 +9,10 @@ public class BoostController : MonoBehaviour
     [SerializeField] private Slider boostBarVertical;
     [SerializeField] private Slider boostBarHorizontal;
 
+    [Header("UI Follow Settings")]
+    [SerializeField] private Vector2 verticalScreenOffset = new Vector2(110f, 60f);
+    [SerializeField] private Vector2 horizontalScreenOffset = new Vector2(110f, -60f);
+
     [Header("Boost Settings")]
     [SerializeField] private float maxBoost = 100f;
     [SerializeField] private float boostConsumptionRate = 20f; // /sec
@@ -31,6 +35,7 @@ public class BoostController : MonoBehaviour
     private float currentBoost;
     private Color leftOriginalColor = Color.white;
     private Color rightOriginalColor = Color.white;
+    private Camera cachedCamera;
 
     // 他スクリプト用読み取り
     public bool IsBoosting => isBoosting;
@@ -54,6 +59,7 @@ public class BoostController : MonoBehaviour
         ConfigureBoostUI();
         UpdateBoostUI();
         SetBoostUIVisibility(ShouldShowBoostUI());
+        UpdateBoostUIPosition();
     }
 
     private void OnDisable()
@@ -90,6 +96,7 @@ public class BoostController : MonoBehaviour
 
         UpdateBoostUI();
         SetBoostUIVisibility(ShouldShowBoostUI());
+        UpdateBoostUIPosition();
     }
 
     private void OnBoostPerformed(InputAction.CallbackContext ctx)
@@ -156,7 +163,6 @@ public class BoostController : MonoBehaviour
         if (rect)
         {
             rect.anchorMin = rect.anchorMax = new Vector2(0.5f, 0.5f);
-            rect.anchoredPosition = new Vector2(90f, 0f);
             rect.sizeDelta = new Vector2(18f, 140f);
         }
 
@@ -199,6 +205,68 @@ public class BoostController : MonoBehaviour
                 labelText.enableWordWrapping = false;
             }
         }
+    }
+
+    private void UpdateBoostUIPosition()
+    {
+        UpdateSliderPosition(boostBarVertical, verticalScreenOffset);
+        UpdateSliderPosition(boostBarHorizontal, horizontalScreenOffset);
+    }
+
+    private void UpdateSliderPosition(Slider slider, Vector2 screenOffset)
+    {
+        if (!slider)
+        {
+            return;
+        }
+
+        RectTransform sliderRect = slider.GetComponent<RectTransform>();
+        if (!sliderRect)
+        {
+            return;
+        }
+
+        Canvas canvas = slider.GetComponentInParent<Canvas>();
+        if (!canvas)
+        {
+            return;
+        }
+
+        RectTransform canvasRect = canvas.GetComponent<RectTransform>();
+        if (!canvasRect)
+        {
+            return;
+        }
+
+        Camera camera = GetCameraForCanvas(canvas);
+        Vector3 worldPosition = transform.position;
+        Vector2 screenPoint = RectTransformUtility.WorldToScreenPoint(camera, worldPosition);
+        Vector2 targetScreenPoint = screenPoint + screenOffset;
+
+        if (RectTransformUtility.ScreenPointToLocalPointInRectangle(canvasRect, targetScreenPoint, camera, out Vector2 localPoint))
+        {
+            sliderRect.anchoredPosition = localPoint;
+        }
+    }
+
+    private Camera GetCameraForCanvas(Canvas canvas)
+    {
+        if (canvas.renderMode == RenderMode.ScreenSpaceOverlay)
+        {
+            return null;
+        }
+
+        if (canvas.worldCamera)
+        {
+            return canvas.worldCamera;
+        }
+
+        if (!cachedCamera)
+        {
+            cachedCamera = Camera.main;
+        }
+
+        return cachedCamera;
     }
 
     private bool ShouldShowBoostUI()

--- a/Assets/Scripts/BoostController.cs
+++ b/Assets/Scripts/BoostController.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -6,12 +7,10 @@ using UnityEngine.UI;
 public class BoostController : MonoBehaviour
 {
     [Header("UI")]
-    [SerializeField] private Slider boostBarVertical;
-    [SerializeField] private Slider boostBarHorizontal;
+    [SerializeField] private Slider[] boostBars;
 
     [Header("UI Follow Settings")]
-    [SerializeField] private Vector2 verticalScreenOffset = new Vector2(110f, 60f);
-    [SerializeField] private Vector2 horizontalScreenOffset = new Vector2(110f, -60f);
+    [SerializeField] private Vector2 screenOffset = new Vector2(120f, 40f);
 
     [Header("Boost Settings")]
     [SerializeField] private float maxBoost = 100f;
@@ -137,20 +136,18 @@ public class BoostController : MonoBehaviour
     private void UpdateBoostUI()
     {
         float v = (maxBoost <= 0f) ? 0f : currentBoost / maxBoost;
-        if (boostBarVertical)
+        foreach (Slider slider in EnumerateBoostBars())
         {
-            boostBarVertical.value = v;
-        }
-        if (boostBarHorizontal)
-        {
-            boostBarHorizontal.value = v;
+            slider.value = v;
         }
     }
 
     private void ConfigureBoostUI()
     {
-        ConfigureBoostSlider(boostBarVertical);
-        ConfigureBoostSlider(boostBarHorizontal);
+        foreach (Slider slider in EnumerateBoostBars())
+        {
+            ConfigureBoostSlider(slider);
+        }
     }
 
     private void ConfigureBoostSlider(Slider slider)
@@ -209,8 +206,10 @@ public class BoostController : MonoBehaviour
 
     private void UpdateBoostUIPosition()
     {
-        UpdateSliderPosition(boostBarVertical, verticalScreenOffset);
-        UpdateSliderPosition(boostBarHorizontal, horizontalScreenOffset);
+        foreach (Slider slider in EnumerateBoostBars())
+        {
+            UpdateSliderPosition(slider, screenOffset);
+        }
     }
 
     private void UpdateSliderPosition(Slider slider, Vector2 screenOffset)
@@ -271,23 +270,33 @@ public class BoostController : MonoBehaviour
 
     private bool ShouldShowBoostUI()
     {
-        return isBoosting || currentBoost < maxBoost;
+        return isBoosting;
     }
 
     private void SetBoostUIVisibility(bool visible)
     {
-        if (boostBarVertical)
+        foreach (Slider slider in EnumerateBoostBars())
         {
-            if (boostBarVertical.gameObject.activeSelf != visible)
+            GameObject sliderGO = slider.gameObject;
+            if (sliderGO.activeSelf != visible)
             {
-                boostBarVertical.gameObject.SetActive(visible);
+                sliderGO.SetActive(visible);
             }
         }
-        if (boostBarHorizontal)
+    }
+
+    private IEnumerable<Slider> EnumerateBoostBars()
+    {
+        if (boostBars == null)
         {
-            if (boostBarHorizontal.gameObject.activeSelf != visible)
+            yield break;
+        }
+
+        foreach (Slider slider in boostBars)
+        {
+            if (slider)
             {
-                boostBarHorizontal.gameObject.SetActive(visible);
+                yield return slider;
             }
         }
     }


### PR DESCRIPTION
## Summary
- hide the boost gauges whenever the player is not actively boosting
- reconfigure both boost sliders to appear as compact vertical meters on the player's right side
- align boost labels and fill behaviour so the meters drain from top to bottom

## Testing
- not run (Unity project)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f5cf77c9c832188c7f44d570e2ae4)