### PR TITLE
Align boost FOV with orientation defaults

### DIFF
--- a/Assets/Scripts/Controls/PlayerController.cs
+++ b/Assets/Scripts/Controls/PlayerController.cs
@@ -37,6 +37,7 @@ public class PlayerController : MonoBehaviour
     public BoostController boost;   // ← BoostController をドラッグで割り当て
     public Animator animator;       // 任意
     [SerializeField] private CinemachineVirtualCamera virtualCamera;
+    [SerializeField] private VCamOrientationSwitcher orientationSwitcher;
     [SerializeField] private float boostFovIncrease = 5f;
     [SerializeField] private float boostFovAdjustSpeed = 10f;
 
@@ -53,7 +54,6 @@ public class PlayerController : MonoBehaviour
     private float inertiaSpeed = 0f;
     private float inspectorCameraFov;
     private bool inspectorCameraFovCaptured;
-    private bool wasBoosting;
     private float currentForwardSpeed = 0f;
 
     void OnEnable()
@@ -83,6 +83,7 @@ public class PlayerController : MonoBehaviour
             if (virtualCamera)
             {
                 ConfigureCameraWorldUp();
+                EnsureOrientationSwitcher();
                 if (!inspectorCameraFovCaptured)
                 {
                     inspectorCameraFov = virtualCamera.m_Lens.FieldOfView;
@@ -92,15 +93,15 @@ public class PlayerController : MonoBehaviour
         }
         if (virtualCamera)
         {
+            EnsureOrientationSwitcher();
+
             if (!inspectorCameraFovCaptured)
             {
                 inspectorCameraFov = virtualCamera.m_Lens.FieldOfView;
                 inspectorCameraFovCaptured = true;
             }
 
-            float baseFov = inspectorCameraFovCaptured
-                ? inspectorCameraFov
-                : virtualCamera.m_Lens.FieldOfView;
+            float baseFov = GetBaseFov();
 
             float targetFov = isBoosting
                 ? baseFov + Mathf.Max(0f, boostFovIncrease)
@@ -111,8 +112,6 @@ public class PlayerController : MonoBehaviour
                 ? Mathf.MoveTowards(current, targetFov, boostFovAdjustSpeed * Time.deltaTime)
                 : targetFov;
             virtualCamera.m_Lens.FieldOfView = next;
-
-            wasBoosting = isBoosting;
         }
 
         // アニメーター
@@ -262,8 +261,35 @@ public class PlayerController : MonoBehaviour
         {
             inspectorCameraFov = virtualCamera.m_Lens.FieldOfView;
             inspectorCameraFovCaptured = true;
+            EnsureOrientationSwitcher();
             ConfigureCameraWorldUp();
         }
+    }
+
+    private float GetBaseFov()
+    {
+        if (orientationSwitcher)
+        {
+            return orientationSwitcher.GetDefaultFieldOfView();
+        }
+
+        if (!inspectorCameraFovCaptured)
+        {
+            inspectorCameraFov = virtualCamera.m_Lens.FieldOfView;
+            inspectorCameraFovCaptured = true;
+        }
+
+        return inspectorCameraFov;
+    }
+
+    private void EnsureOrientationSwitcher()
+    {
+        if (orientationSwitcher)
+            return;
+
+        orientationSwitcher = GetComponentInChildren<VCamOrientationSwitcher>();
+        if (!orientationSwitcher && virtualCamera)
+            orientationSwitcher = virtualCamera.GetComponent<VCamOrientationSwitcher>();
     }
 
     private void UpdateOrientation(float deltaTime)

--- a/Assets/Scripts/VCamOrientationSwitcher.cs
+++ b/Assets/Scripts/VCamOrientationSwitcher.cs
@@ -42,16 +42,24 @@ public class VCamOrientationSwitcher : MonoBehaviour
         if (_dirty) { ApplyByCurrentOrientation(); _dirty = false; }
     }
 
+    public bool IsPortrait() => Screen.height >= Screen.width;
+
+    public float GetDefaultFieldOfView(bool? portrait = null)
+    {
+        bool isPortrait = portrait ?? IsPortrait();
+        return isPortrait ? fovPortrait : fovLandscape;
+    }
+
     void ApplyByCurrentOrientation()
     {
         if (vcam == null) return;
 
-        bool isPortrait = Screen.height >= Screen.width;
+        bool isPortrait = IsPortrait();
 
         // FOV（正投影なら OrthographicSize を使う）
         var lens = vcam.m_Lens;
         if (!lens.Orthographic)
-            lens.FieldOfView = isPortrait ? fovPortrait : fovLandscape;
+            lens.FieldOfView = GetDefaultFieldOfView(isPortrait);
         else
             lens.OrthographicSize = isPortrait ? 6.0f : 5.0f;
         vcam.m_Lens = lens;


### PR DESCRIPTION
## Summary
- expose the VCamOrientationSwitcher default field-of-view values for the active orientation
- update PlayerController to use the orientation-specific defaults when adjusting boost FOV and refresh the switcher reference automatically

## Testing
- not run (Unity project)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913af92775c8321b7983c360e39c955)