### PR TITLE
Prevent keys from spawning inside geometry

### DIFF
--- a/Assets/Scripts/ObjectSpawner.cs
+++ b/Assets/Scripts/ObjectSpawner.cs
@@ -53,8 +53,34 @@ public class ObjectSpawner : MonoBehaviour
             if (Physics.Raycast(rayOrigin, Vector3.down, out RaycastHit hit, maxRayDistance, surfaceLayers, QueryTriggerInteraction.Ignore))
             {
                 Vector3 projected = hit.point + Vector3.up * surfaceOffset;
+                Collider hitCollider = hit.collider;
+                bool blocked = false;
+                Collider[] overlaps = Physics.OverlapSphere(projected, spawnRadius, blockingLayers, QueryTriggerInteraction.Ignore);
 
-                if (!Physics.CheckSphere(projected, spawnRadius, blockingLayers, QueryTriggerInteraction.Ignore))
+                for (int i = 0; i < overlaps.Length; i++)
+                {
+                    Collider overlap = overlaps[i];
+
+                    if (overlap == hitCollider)
+                    {
+                        continue;
+                    }
+
+                    if (hitCollider != null && overlap.transform.IsChildOf(hitCollider.transform))
+                    {
+                        continue;
+                    }
+
+                    if (hitCollider != null && hitCollider.transform.IsChildOf(overlap.transform))
+                    {
+                        continue;
+                    }
+
+                    blocked = true;
+                    break;
+                }
+
+                if (!blocked)
                 {
                     candidate = projected;
                     return candidate;

--- a/Assets/Scripts/ObjectSpawner.cs
+++ b/Assets/Scripts/ObjectSpawner.cs
@@ -1,87 +1,94 @@
-        using System.Collections;
-        using System.Collections.Generic;
-        using UnityEngine;
+using UnityEngine;
 
-        public class ObjectSpawner : MonoBehaviour
+public class ObjectSpawner : MonoBehaviour
+{
+    public GameObject[] keyPrefabs; // 4つのKeyのプレハブを格納する配列
+    public BoxCollider boundary; // スポーン範囲を定義するBoundary
+    public float spawnRadius = 0.5f; // 半径のコリジョンチェック
+    public LayerMask blockingLayers = ~0; // スポーンをブロックするレイヤーマスク
+    public LayerMask surfaceLayers = ~0; // スポーンさせたい面を取得するためのレイヤーマスク
+    [Min(0f)] public float surfaceOffset = 0.05f; // ヒットした面からキーを浮かせる高さ
+    [Min(0f)] public float raycastPadding = 0.5f; // レイキャスト開始位置の余裕
+
+    private int objectsCollected = 0;
+    private int currentKeyIndex = 0; // 現在のKeyのインデックス
+
+    private void Awake()
+    {
+        if (boundary == null)
         {
-            public GameObject[] keyPrefabs; // 4つのKeyのプレハブを格納する配列
-            public BoxCollider boundary; // スポーン範囲を定義するBoundary
-            public float spawnRadius = 0.5f; // 半径のコリジョンチェック
-            public LayerMask blockingLayers = ~0; // スポーンをブロックするレイヤーマスク
-
-            private int objectsCollected = 0;
-            private int currentKeyIndex = 0; // 現在のKeyのインデックス
-
-            private void Awake()
+            GameObject boundaryObject = GameObject.FindWithTag("boundary");
+            if (boundaryObject != null)
             {
-                if (boundary == null)
-                {
-                    GameObject boundaryObject = GameObject.FindWithTag("boundary");
-                    if (boundaryObject != null)
-                    {
-                        boundary = boundaryObject.GetComponent<BoxCollider>();
-                    }
-                }
-
-                if (boundary == null)
-                {
-                    Debug.LogError("Boundary not set for ObjectSpawner.");
-                }
+                boundary = boundaryObject.GetComponent<BoxCollider>();
             }
-
-        public Vector3 GetRandomPosition()
-        {
-                if (boundary == null)
-                {
-                    Debug.LogError("Boundary not set for ObjectSpawner.");
-                    return Vector3.zero;
-                }
-
-                const int maxAttempts = 20;
-                Vector3 candidate = Vector3.zero;
-                Vector3 center = boundary.center;
-                Vector3 size = boundary.size;
-                for (int i = 0; i < maxAttempts; i++)
-                {
-                    Vector3 localOffset = new Vector3(
-                        Random.Range(-size.x * 0.5f, size.x * 0.5f),
-                        Random.Range(-size.y * 0.5f, size.y * 0.5f),
-                        Random.Range(-size.z * 0.5f, size.z * 0.5f)
-                    );
-                    candidate = boundary.transform.TransformPoint(center + localOffset);
-
-                    if (!Physics.CheckSphere(candidate, spawnRadius, blockingLayers))
-                    {
-                        return candidate;
-                    }
-                }
-
-                Debug.LogWarning($"No valid spawn position found after {maxAttempts} attempts. Returning last candidate: {candidate}");
-                return candidate;
         }
 
-            public void SpawnObject()
+        if (boundary == null)
+        {
+            Debug.LogError("Boundary not set for ObjectSpawner.");
+        }
+    }
+
+    public Vector3 GetRandomPosition()
+    {
+        if (boundary == null)
+        {
+            Debug.LogError("Boundary not set for ObjectSpawner.");
+            return Vector3.zero;
+        }
+
+        const int maxAttempts = 20;
+        Bounds bounds = boundary.bounds;
+        Vector3 candidate = bounds.center;
+        float maxRayDistance = bounds.size.y + raycastPadding * 2f;
+
+        for (int attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            float randomX = Random.Range(bounds.min.x, bounds.max.x);
+            float randomZ = Random.Range(bounds.min.z, bounds.max.z);
+            float startY = bounds.max.y + raycastPadding;
+            Vector3 rayOrigin = new Vector3(randomX, startY, randomZ);
+
+            if (Physics.Raycast(rayOrigin, Vector3.down, out RaycastHit hit, maxRayDistance, surfaceLayers, QueryTriggerInteraction.Ignore))
             {
-                if(objectsCollected >= 4){
-                    return;
-                }
+                Vector3 projected = hit.point + Vector3.up * surfaceOffset;
 
-                Vector3 randomPosition = GetRandomPosition();
-
-                GameObject prefabToSpawn = keyPrefabs[currentKeyIndex];
-                GameObject spawnedObject = Instantiate(prefabToSpawn, randomPosition, Quaternion.identity);
-                spawnedObject.SetActive(false);
-
-                spawnedObject.SetActive(true);
-
-                Debug.Log("Object spawned at position: " + randomPosition);
-
-                objectsCollected++;
-                currentKeyIndex++;
-
-                if (currentKeyIndex >= keyPrefabs.Length)
+                if (!Physics.CheckSphere(projected, spawnRadius, blockingLayers, QueryTriggerInteraction.Ignore))
                 {
-                    currentKeyIndex = 0;
+                    candidate = projected;
+                    return candidate;
                 }
             }
         }
+
+        Debug.LogWarning($"No valid spawn position found after {maxAttempts} attempts. Returning last candidate: {candidate}");
+        return candidate;
+    }
+
+    public void SpawnObject()
+    {
+        if (objectsCollected >= 4)
+        {
+            return;
+        }
+
+        Vector3 randomPosition = GetRandomPosition();
+
+        GameObject prefabToSpawn = keyPrefabs[currentKeyIndex];
+        GameObject spawnedObject = Instantiate(prefabToSpawn, randomPosition, Quaternion.identity);
+        spawnedObject.SetActive(false);
+
+        spawnedObject.SetActive(true);
+
+        Debug.Log("Object spawned at position: " + randomPosition);
+
+        objectsCollected++;
+        currentKeyIndex++;
+
+        if (currentKeyIndex >= keyPrefabs.Length)
+        {
+            currentKeyIndex = 0;
+        }
+    }
+}

--- a/Assets/Scripts/ObjectSpawner.cs
+++ b/Assets/Scripts/ObjectSpawner.cs
@@ -40,7 +40,8 @@ public class ObjectSpawner : MonoBehaviour
 
         const int maxAttempts = 20;
         Bounds bounds = boundary.bounds;
-        Vector3 candidate = bounds.center;
+        Vector3 fallback = bounds.center + Vector3.up * surfaceOffset;
+        bool hasFallback = false;
         float maxRayDistance = bounds.size.y + raycastPadding * 2f;
 
         for (int attempt = 0; attempt < maxAttempts; attempt++)
@@ -82,14 +83,21 @@ public class ObjectSpawner : MonoBehaviour
 
                 if (!blocked)
                 {
-                    candidate = projected;
-                    return candidate;
+                    return projected;
                 }
+
+                fallback = projected;
+                hasFallback = true;
+            }
+            else
+            {
+                fallback = new Vector3(randomX, bounds.center.y + surfaceOffset, randomZ);
+                hasFallback = true;
             }
         }
 
-        Debug.LogWarning($"No valid spawn position found after {maxAttempts} attempts. Returning last candidate: {candidate}");
-        return candidate;
+        Debug.LogWarning($"No valid spawn position found after {maxAttempts} attempts. Returning fallback position: {fallback}");
+        return hasFallback ? fallback : bounds.center;
     }
 
     public void SpawnObject()


### PR DESCRIPTION
## Summary
- project random spawn positions down onto valid surfaces before spawning keys
- expose surface and blocking layer masks plus offsets to keep spawned keys clear of surrounding geometry

## Testing
- not run (Unity project)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914eca970688321b585f78047633e9d)