### PR TITLE
Add reusable highlight helpers for trace UI

### DIFF
--- a/Assets/Scripts/UI.meta
+++ b/Assets/Scripts/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e9798a0c03b4294fa6548f5bdb756a9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/ListEntryHighlight.cs
+++ b/Assets/Scripts/UI/ListEntryHighlight.cs
@@ -1,0 +1,164 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+[DisallowMultipleComponent]
+[RequireComponent(typeof(Selectable))]
+public sealed class ListEntryHighlight : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, ISelectHandler, IDeselectHandler
+{
+    [Header("Highlight visuals")]
+    [SerializeField] private Graphic highlightGraphic;
+    [SerializeField] private GameObject highlightObject;
+    [SerializeField] private Color highlightedColor = new Color(0.94f, 0.94f, 0.94f, 1f);
+    [SerializeField, Tooltip("When false the target graphic will retain its original colour.")]
+    private bool tintGraphic = true;
+
+    private ListSelectionCoordinator coordinator;
+    private Selectable selectable;
+    private Color originalColor;
+    private bool colorCaptured;
+    private bool isPointerInside;
+    private bool isSelected;
+
+    private void Awake()
+    {
+        selectable = GetComponent<Selectable>();
+        if (!highlightGraphic && selectable)
+        {
+            highlightGraphic = selectable.targetGraphic;
+        }
+
+        coordinator = GetComponentInParent<ListSelectionCoordinator>();
+        coordinator?.RegisterEntry(this);
+
+        CaptureOriginalColor();
+    }
+
+    private void OnEnable()
+    {
+        CaptureOriginalColor();
+        UpdateVisual();
+    }
+
+    private void OnDisable()
+    {
+        isPointerInside = false;
+        isSelected = false;
+        UpdateVisual();
+    }
+
+    private void OnDestroy()
+    {
+        coordinator?.UnregisterEntry(this);
+    }
+
+    public void HandleClick()
+    {
+        if (!IsInteractable())
+        {
+            return;
+        }
+
+        if (coordinator != null)
+        {
+            coordinator.RequestSelection(this);
+        }
+        else
+        {
+            SetSelected(true);
+        }
+    }
+
+    internal void AttachCoordinator(ListSelectionCoordinator listCoordinator)
+    {
+        coordinator = listCoordinator;
+    }
+
+    internal void SetSelected(bool selected)
+    {
+        isSelected = selected;
+        UpdateVisual();
+    }
+
+    public void OnPointerEnter(PointerEventData eventData)
+    {
+        if (!IsInteractable())
+        {
+            return;
+        }
+
+        isPointerInside = true;
+        UpdateVisual();
+    }
+
+    public void OnPointerExit(PointerEventData eventData)
+    {
+        if (!IsInteractable())
+        {
+            return;
+        }
+
+        isPointerInside = false;
+        UpdateVisual();
+    }
+
+    public void OnSelect(BaseEventData eventData)
+    {
+        if (!IsInteractable())
+        {
+            return;
+        }
+
+        if (coordinator != null)
+        {
+            coordinator.RequestSelection(this);
+        }
+        else
+        {
+            SetSelected(true);
+        }
+    }
+
+    public void OnDeselect(BaseEventData eventData)
+    {
+        if (coordinator == null)
+        {
+            SetSelected(false);
+        }
+    }
+
+    private void UpdateVisual()
+    {
+        var highlight = (isPointerInside && IsInteractable()) || isSelected;
+
+        if (highlightObject)
+        {
+            if (highlightObject.activeSelf != highlight)
+            {
+                highlightObject.SetActive(highlight);
+            }
+        }
+
+        if (highlightGraphic && tintGraphic)
+        {
+            CaptureOriginalColor();
+            highlightGraphic.color = highlight ? highlightedColor : originalColor;
+        }
+    }
+
+    private bool IsInteractable()
+    {
+        return selectable == null || selectable.IsInteractable();
+    }
+
+    private void CaptureOriginalColor()
+    {
+        if (!tintGraphic || !highlightGraphic || colorCaptured)
+        {
+            return;
+        }
+
+        originalColor = highlightGraphic.color;
+        colorCaptured = true;
+    }
+}

--- a/Assets/Scripts/UI/ListEntryHighlight.cs.meta
+++ b/Assets/Scripts/UI/ListEntryHighlight.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d2f8352d0dd94a0c8b2f1a91c9d3c4b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/ListSelectionCoordinator.cs
+++ b/Assets/Scripts/UI/ListSelectionCoordinator.cs
@@ -1,0 +1,138 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public sealed class ListSelectionCoordinator : MonoBehaviour
+{
+    [Tooltip("Optional static entries that will be pre-registered in the displayed order.")]
+    [SerializeField] private ListEntryHighlight[] initialEntries = System.Array.Empty<ListEntryHighlight>();
+    [SerializeField, Tooltip("Automatically select this entry index when the component becomes active. Set to -1 to skip.")]
+    private int defaultSelectionIndex = -1;
+
+    private readonly List<ListEntryHighlight> registeredEntries = new();
+    private ListEntryHighlight current;
+
+    private void Awake()
+    {
+        if (initialEntries == null)
+        {
+            return;
+        }
+
+        foreach (var entry in initialEntries)
+        {
+            RegisterEntry(entry);
+        }
+    }
+
+    private void OnEnable()
+    {
+        if (current != null)
+        {
+            current.SetSelected(true);
+            return;
+        }
+
+        if (defaultSelectionIndex >= 0)
+        {
+            SelectByIndex(defaultSelectionIndex);
+        }
+    }
+
+    public void RegisterEntry(ListEntryHighlight entry)
+    {
+        if (!entry)
+        {
+            return;
+        }
+
+        if (registeredEntries.Contains(entry))
+        {
+            entry.AttachCoordinator(this);
+            return;
+        }
+
+        registeredEntries.Add(entry);
+        entry.AttachCoordinator(this);
+    }
+
+    public void UnregisterEntry(ListEntryHighlight entry)
+    {
+        if (!entry)
+        {
+            return;
+        }
+
+        if (registeredEntries.Remove(entry) && current == entry)
+        {
+            current = null;
+        }
+    }
+
+    internal void RequestSelection(ListEntryHighlight entry)
+    {
+        if (!entry)
+        {
+            return;
+        }
+
+        if (current == entry)
+        {
+            entry.SetSelected(true);
+            return;
+        }
+
+        if (current)
+        {
+            current.SetSelected(false);
+        }
+
+        current = entry;
+        current.SetSelected(true);
+    }
+
+    public void SelectEntry(ListEntryHighlight entry)
+    {
+        RequestSelection(entry);
+    }
+
+    public void SelectByIndex(int index)
+    {
+        if (index < 0)
+        {
+            ClearSelection();
+            return;
+        }
+
+        ListEntryHighlight entry = null;
+
+        if (initialEntries != null && index < initialEntries.Length)
+        {
+            entry = initialEntries[index];
+        }
+
+        if (!entry && index < registeredEntries.Count)
+        {
+            entry = registeredEntries[index];
+        }
+
+        if (!entry)
+        {
+            Debug.LogWarning($"ListSelectionCoordinator.SelectByIndex: index {index} is out of range.", this);
+            return;
+        }
+
+        RequestSelection(entry);
+    }
+
+    public void ClearSelection()
+    {
+        if (!current)
+        {
+            return;
+        }
+
+        current.SetSelected(false);
+        current = null;
+    }
+}

--- a/Assets/Scripts/UI/ListSelectionCoordinator.cs.meta
+++ b/Assets/Scripts/UI/ListSelectionCoordinator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0327d8c0ad664601b8f6a570d5649641
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add a reusable `ListEntryHighlight` component that can tint a target graphic and toggle highlight objects on hover/selection
- add a `ListSelectionCoordinator` to keep a single entry highlighted and support default selection for trace-style lists

## Testing
- Not run (Unity project)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163153f5ac8321b9363cd3c776bc25)